### PR TITLE
feat(atalas): add new tag for editions

### DIFF
--- a/editors/shared/components/content-card.tsx
+++ b/editors/shared/components/content-card.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from "react";
 import TagStatus from "./tags-status.js";
 interface AtlasCardProps extends PropsWithChildren {
   tagText?: string;
-  variant?: "gray" | "green";
+  variant?: "gray" | "green" | "blue";
   className?: string;
 }
 

--- a/editors/shared/components/tags-status.tsx
+++ b/editors/shared/components/tags-status.tsx
@@ -1,6 +1,6 @@
 interface TagProps {
   text: string;
-  variant?: "gray" | "green";
+  variant?: "gray" | "green" | "blue";
   className?: string;
 }
 
@@ -11,6 +11,7 @@ const TagStatus = ({ text, variant = "gray", className = "" }: TagProps) => {
     gray: "text-sm bg-gray-200 text-gray-900 border-[#FFFFFF00] font-semibold",
     green:
       "text-sm bg-green-50 text-[#34A853] border-[#FFFFFF00] font-semibold",
+    blue: "text-sm bg-blue-50 text-[#0084FF] border-[#FFFFFF00] font-semibold",
   };
 
   return (

--- a/editors/shared/utils/utils.ts
+++ b/editors/shared/utils/utils.ts
@@ -60,11 +60,11 @@ export const fetchSelectedPHIDOption = (
 };
 
 export const getCardVariant = (mode: EditorMode) => {
-  return mode === "Edition" || mode === "Readonly" ? "gray" : "green";
+  return mode === "Edition" ? "blue" : mode === "Readonly" || mode === "DiffRemoved" ? "gray" : "green";
 };
 
 export const getTagText = (mode: string) => {
-  return mode === "Edition" || mode === "Readonly"
+  return mode === "Edition" ? "Edition Atlas" : mode === "Readonly" || mode === "DiffRemoved"
     ? "Official Atlas"
     : "Atlas Draft";
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/iatpFQ28/933-unified-view-edit-mode-for-no-parent-document-types

## Description
Unified/Edit-> tag should be “Edition Atlas”