### PR TITLE
fix: initial option & save in PHID field

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -7,7 +7,12 @@ import {
   UrlField,
 } from "@powerhousedao/design-system/scalars";
 import ContentCard from "../../shared/components/content-card.js";
-import { cb, getCardVariant, getTagText } from "../../shared/utils/utils.js";
+import {
+  fetchPHIDOptions,
+  fetchSelectedPHIDOption,
+  getCardVariant,
+  getTagText,
+} from "../../shared/utils/utils.js";
 import type { EditorMode } from "../../shared/types.js";
 import { isFormReadOnly } from "../../shared/utils/form-common.js";
 import { getOriginalNotionDocument } from "../../../document-models/utils.js";
@@ -18,17 +23,20 @@ import { EnumDiffField } from "../../shared/components/diff-fields/enum-diff-fie
 import { globalTagsEnumOptions } from "../../shared/utils/common-options.js";
 import { type ParsedNotionDocumentType } from "../../../scripts/apply-changes/atlas-base/NotionTypes.js";
 import { UrlDiffField } from "../../shared/components/diff-fields/url-diff-field.js";
+import { type PHIDOption } from "@powerhousedao/design-system/ui";
 
 interface ExploratoryFormProps {
   onSubmit: (data: Record<string, any>) => void;
   documentState: Record<string, any>;
   mode: EditorMode;
+  parentPHIDInitialOption?: PHIDOption;
 }
 
 export function ExploratoryForm({
   onSubmit,
   documentState,
   mode,
+  parentPHIDInitialOption,
 }: ExploratoryFormProps) {
   const isReadOnly = isFormReadOnly(mode);
   const cardVariant = getCardVariant(mode);
@@ -115,12 +123,15 @@ export function ExploratoryForm({
               disabled={isReadOnly}
               name="parent"
               label="Parent Document"
-              placeholder="PHID"
-              onBlur={triggerSubmit}
-              fetchOptionsCallback={cb}
-              fetchSelectedOptionCallback={(x) => cb(x).then((x) => x[5])}
+              placeholder="phd:"
               variant="withValueTitleAndDescription"
-              allowUris={true}
+              allowUris
+              initialOptions={
+                parentPHIDInitialOption ? [parentPHIDInitialOption] : undefined
+              }
+              fetchOptionsCallback={fetchPHIDOptions}
+              fetchSelectedOptionCallback={fetchSelectedPHIDOption}
+              onBlur={triggerSubmit}
             />
             <BooleanField
               disabled={isReadOnly}

--- a/editors/atlas-exploratory-editor/editor.tsx
+++ b/editors/atlas-exploratory-editor/editor.tsx
@@ -8,12 +8,20 @@ import {
 import { EditorLayout } from "../shared/components/EditorLayout.js";
 import { SplitView } from "../shared/components/SplitView.js";
 import { ExploratoryForm } from "./components/ExploratoryForm.js";
+import { fetchSelectedPHIDOption } from "../shared/utils/utils.js";
 
 export type IProps = EditorProps<AtlasExploratoryDocument>;
 
 export default function Editor(props: IProps) {
   const { dispatch } = props;
-  const documentState = props.document.state.global;
+  const documentState = {
+    ...props.document.state.global,
+    parent:
+      props.document.state.global.parent?.length > 0
+        ? `phd:${props.document.state.global.parent[0]}`
+        : "",
+  };
+  const parentPHIDInitialOption = fetchSelectedPHIDOption(documentState.parent);
 
   const onSubmit = (data: Record<string, any>) => {
     if (data["docNo"] !== undefined) {
@@ -33,7 +41,12 @@ export default function Editor(props: IProps) {
       dispatch(actions.setContent({ content: data["content"] as string }));
     }
     if (data["parent"] !== undefined) {
-      dispatch(actions.setParent({ parent: [data["parent"] as string] }));
+      if (data["parent"] === null) {
+        dispatch(actions.setParent({ parent: [] }));
+      } else {
+        const newParentId = (data["parent"] as string).split(":")[1];
+        dispatch(actions.setParent({ parent: [newParentId] }));
+      }
     }
 
     // TODO: save other fields
@@ -76,6 +89,7 @@ export default function Editor(props: IProps) {
                 onSubmit={onSubmit}
                 documentState={documentState}
                 mode={isEditMode ? "Edition" : "DiffRemoved"}
+                parentPHIDInitialOption={parentPHIDInitialOption}
               />
             }
             right={
@@ -83,6 +97,7 @@ export default function Editor(props: IProps) {
                 onSubmit={onSubmit}
                 documentState={documentState}
                 mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
+                parentPHIDInitialOption={parentPHIDInitialOption}
               />
             }
           />
@@ -91,6 +106,7 @@ export default function Editor(props: IProps) {
             onSubmit={onSubmit}
             documentState={documentState}
             mode={isEditMode ? "Edition" : "Readonly"}
+            parentPHIDInitialOption={parentPHIDInitialOption}
           />
         )
       }

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -22,14 +22,18 @@ interface FoundationFormProps {
   onSubmit: (data: Record<string, any>) => void;
   documentState: Record<string, any>;
   mode: EditorMode;
-  initialPHIDOption: PHIDOption;
+  parentPHIDInitialOption?: PHIDOption;
+  originalContextDataPHIDInitialOption?: PHIDOption;
+  referencesPHIDInitialOption?: PHIDOption;
 }
 
 export function FoundationForm({
   onSubmit,
   documentState,
   mode,
-  initialPHIDOption,
+  parentPHIDInitialOption,
+  originalContextDataPHIDInitialOption,
+  referencesPHIDInitialOption,
 }: FoundationFormProps) {
   const isReadOnly = isFormReadOnly(mode);
   const cardVariant = getCardVariant(mode);
@@ -142,7 +146,11 @@ export function FoundationForm({
                 placeholder="phd:"
                 variant="withValueTitleAndDescription"
                 allowUris
-                initialOptions={[initialPHIDOption]}
+                initialOptions={
+                  parentPHIDInitialOption
+                    ? [parentPHIDInitialOption]
+                    : undefined
+                }
                 fetchOptionsCallback={fetchPHIDOptions}
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}
@@ -156,7 +164,11 @@ export function FoundationForm({
                 placeholder="phd:"
                 variant="withValueTitleAndDescription"
                 allowUris
-                initialOptions={[initialPHIDOption]}
+                initialOptions={
+                  originalContextDataPHIDInitialOption
+                    ? [originalContextDataPHIDInitialOption]
+                    : undefined
+                }
                 fetchOptionsCallback={fetchPHIDOptions}
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}
@@ -197,7 +209,11 @@ export function FoundationForm({
                 placeholder="phd:"
                 variant="withValueTitleAndDescription"
                 allowUris
-                initialOptions={[initialPHIDOption]}
+                initialOptions={
+                  referencesPHIDInitialOption
+                    ? [referencesPHIDInitialOption]
+                    : undefined
+                }
                 fetchOptionsCallback={fetchPHIDOptions}
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}

--- a/editors/atlas-foundation-editor/editor.tsx
+++ b/editors/atlas-foundation-editor/editor.tsx
@@ -9,6 +9,7 @@ import {
 import { EditorLayout } from "../shared/components/EditorLayout.js";
 import { SplitView } from "../shared/components/SplitView.js";
 import { FoundationForm } from "./components/FoundationForm.js";
+import { fetchSelectedPHIDOption } from "../shared/utils/utils.js";
 
 export type IProps = EditorProps<AtlasFoundationDocument>;
 
@@ -17,23 +18,28 @@ export default function Editor(props: IProps) {
 
   // TODO: remove or update this once all the data in global state is in the expected format or the design is updated
   const originalDocumentState = props.document.state.global;
-  const originalParentId = originalDocumentState.parent?.id
+  const parentId = originalDocumentState.parent?.id
     ? `phd:${originalDocumentState.parent?.id}`
     : "";
+  const originalContextDataId = originalDocumentState.originalContextData[0]?.id
+    ? `phd:${originalDocumentState.originalContextData[0].id}`
+    : "";
+  const referencesId = originalDocumentState.references[0]?.id
+    ? `phd:${originalDocumentState.references[0].id}`
+    : "";
+
   const documentState = {
     ...originalDocumentState,
-    parent: originalParentId,
+    parent: parentId,
     provenance: originalDocumentState.provenance[0] || "",
-    originalContextData: originalDocumentState.originalContextData[0]?.id || "",
-    references: originalDocumentState.references[0]?.id || "",
+    originalContextData: originalContextDataId,
+    references: referencesId,
   };
-  const initialPHIDOption = {
-    value: originalParentId,
-    title: `${originalDocumentState.parent?.docNo || ""} - ${originalDocumentState.parent?.name || ""}`,
-    path: "sky/atlas-foundation",
-    icon: "File" as const,
-    description: "",
-  };
+  const parentPHIDInitialOption = fetchSelectedPHIDOption(parentId);
+  const originalContextDataPHIDInitialOption = fetchSelectedPHIDOption(
+    originalContextDataId,
+  );
+  const referencesPHIDInitialOption = fetchSelectedPHIDOption(referencesId);
 
   const onSubmit = (data: Record<string, any>) => {
     if (data["docNo"] !== undefined) {
@@ -58,13 +64,26 @@ export default function Editor(props: IProps) {
       dispatch(actions.setContent({ content: data["content"] as string }));
     }
     if (data["parent"] !== undefined) {
-      const parentId = (data["parent"] as string).split(":")[1];
-      dispatch(actions.setParent({ id: parentId }));
+      if (data["parent"] === null) {
+        dispatch(actions.setParent({ id: "" }));
+      } else {
+        const newParentId = (data["parent"] as string).split(":")[1];
+        dispatch(actions.setParent({ id: newParentId }));
+      }
     }
     if (data["originalContextData"] !== undefined) {
-      dispatch(
-        actions.addContextData({ id: data["originalContextData"] as string }),
-      );
+      if (data["originalContextData"] === null) {
+        dispatch(
+          actions.removeContextData({
+            id: documentState.originalContextData.split(":")[1],
+          }),
+        );
+      } else {
+        const newOriginalContextDataId = (
+          data["originalContextData"] as string
+        ).split(":")[1];
+        dispatch(actions.addContextData({ id: newOriginalContextDataId }));
+      }
     }
     if (data["provenance"] !== undefined) {
       dispatch(
@@ -93,7 +112,16 @@ export default function Editor(props: IProps) {
       }
     }
     if (data["references"] !== undefined) {
-      dispatch(actions.addReference({ id: data["references"] as string }));
+      if (data["references"] === null) {
+        dispatch(
+          actions.removeReference({
+            id: documentState.references.split(":")[1],
+          }),
+        );
+      } else {
+        const newReferenceId = (data["references"] as string).split(":")[1];
+        dispatch(actions.addReference({ id: newReferenceId }));
+      }
     }
   };
 
@@ -112,7 +140,11 @@ export default function Editor(props: IProps) {
                 onSubmit={onSubmit}
                 documentState={documentState}
                 mode={isEditMode ? "Edition" : "DiffRemoved"}
-                initialPHIDOption={initialPHIDOption}
+                parentPHIDInitialOption={parentPHIDInitialOption}
+                originalContextDataPHIDInitialOption={
+                  originalContextDataPHIDInitialOption
+                }
+                referencesPHIDInitialOption={referencesPHIDInitialOption}
               />
             }
             right={
@@ -120,7 +152,11 @@ export default function Editor(props: IProps) {
                 onSubmit={onSubmit}
                 documentState={documentState}
                 mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
-                initialPHIDOption={initialPHIDOption}
+                parentPHIDInitialOption={parentPHIDInitialOption}
+                originalContextDataPHIDInitialOption={
+                  originalContextDataPHIDInitialOption
+                }
+                referencesPHIDInitialOption={referencesPHIDInitialOption}
               />
             }
           />
@@ -129,7 +165,11 @@ export default function Editor(props: IProps) {
             onSubmit={onSubmit}
             documentState={documentState}
             mode={isEditMode ? "Edition" : "Readonly"}
-            initialPHIDOption={initialPHIDOption}
+            parentPHIDInitialOption={parentPHIDInitialOption}
+            originalContextDataPHIDInitialOption={
+              originalContextDataPHIDInitialOption
+            }
+            referencesPHIDInitialOption={referencesPHIDInitialOption}
           />
         )
       }

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -22,14 +22,18 @@ interface GroundingFormProps {
   onSubmit: (data: Record<string, any>) => void;
   documentState: Record<string, any>;
   mode: EditorMode;
-  initialPHIDOption: PHIDOption;
+  parentPHIDInitialOption?: PHIDOption;
+  originalContextDataPHIDInitialOption?: PHIDOption;
+  referencesPHIDInitialOption?: PHIDOption;
 }
 
 export function GroundingForm({
   onSubmit,
   documentState,
   mode,
-  initialPHIDOption,
+  parentPHIDInitialOption,
+  originalContextDataPHIDInitialOption,
+  referencesPHIDInitialOption,
 }: GroundingFormProps) {
   const isReadOnly = isFormReadOnly(mode);
   const cardVariant = getCardVariant(mode);
@@ -115,7 +119,11 @@ export function GroundingForm({
                 placeholder="phd:"
                 variant="withValueTitleAndDescription"
                 allowUris
-                initialOptions={[initialPHIDOption]}
+                initialOptions={
+                  parentPHIDInitialOption
+                    ? [parentPHIDInitialOption]
+                    : undefined
+                }
                 fetchOptionsCallback={fetchPHIDOptions}
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}
@@ -129,7 +137,11 @@ export function GroundingForm({
                 placeholder="phd:"
                 variant="withValueTitleAndDescription"
                 allowUris
-                initialOptions={[initialPHIDOption]}
+                initialOptions={
+                  originalContextDataPHIDInitialOption
+                    ? [originalContextDataPHIDInitialOption]
+                    : undefined
+                }
                 fetchOptionsCallback={fetchPHIDOptions}
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}
@@ -166,7 +178,11 @@ export function GroundingForm({
                 placeholder="phd:"
                 variant="withValueTitleAndDescription"
                 allowUris
-                initialOptions={[initialPHIDOption]}
+                initialOptions={
+                  referencesPHIDInitialOption
+                    ? [referencesPHIDInitialOption]
+                    : undefined
+                }
                 fetchOptionsCallback={fetchPHIDOptions}
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}


### PR DESCRIPTION
## Ticket
https://trello.com/c/TYC1u6Dl/937-unified-view-edit-mode-for-atlas-foundational-and-grounding-documents

## Description
- PHID: Should show the correct option preview when have initial value. (Foundation & Grounding forms)
- PHID: Should save the correct value. (Foundation & Grounding forms)