### PR TITLE
fix: allow empty in not required String fields (Foundation & Grounding forms)

### DIFF
--- a/editors/atlas-foundation-editor/editor.tsx
+++ b/editors/atlas-foundation-editor/editor.tsx
@@ -9,7 +9,10 @@ import {
 import { EditorLayout } from "../shared/components/EditorLayout.js";
 import { SplitView } from "../shared/components/SplitView.js";
 import { FoundationForm } from "./components/FoundationForm.js";
-import { fetchSelectedPHIDOption } from "../shared/utils/utils.js";
+import {
+  getStringValue,
+  fetchSelectedPHIDOption,
+} from "../shared/utils/utils.js";
 
 export type IProps = EditorProps<AtlasFoundationDocument>;
 
@@ -43,10 +46,12 @@ export default function Editor(props: IProps) {
 
   const onSubmit = (data: Record<string, any>) => {
     if (data["docNo"] !== undefined) {
-      dispatch(actions.setDocNumber({ docNo: data["docNo"] as string }));
+      dispatch(actions.setDocNumber({ docNo: getStringValue(data["docNo"]) }));
     }
     if (data["name"] !== undefined) {
-      dispatch(actions.setFoundationName({ name: data["name"] as string }));
+      dispatch(
+        actions.setFoundationName({ name: getStringValue(data["name"]) }),
+      );
     }
     if (data["atlasType"] !== undefined) {
       dispatch(
@@ -61,7 +66,9 @@ export default function Editor(props: IProps) {
       );
     }
     if (data["content"] !== undefined) {
-      dispatch(actions.setContent({ content: data["content"] as string }));
+      dispatch(
+        actions.setContent({ content: getStringValue(data["content"]) }),
+      );
     }
     if (data["parent"] !== undefined) {
       if (data["parent"] === null) {

--- a/editors/atlas-grounding-editor/editor.tsx
+++ b/editors/atlas-grounding-editor/editor.tsx
@@ -9,7 +9,10 @@ import {
 import { EditorLayout } from "../shared/components/EditorLayout.js";
 import { SplitView } from "../shared/components/SplitView.js";
 import { GroundingForm } from "./components/GroundingForm.js";
-import { fetchSelectedPHIDOption } from "../shared/utils/utils.js";
+import {
+  getStringValue,
+  fetchSelectedPHIDOption,
+} from "../shared/utils/utils.js";
 
 export type IProps = EditorProps<AtlasGroundingDocument>;
 
@@ -43,10 +46,12 @@ export default function Editor(props: IProps) {
 
   const onSubmit = (data: Record<string, any>) => {
     if (data["docNo"] !== undefined) {
-      dispatch(actions.setDocNumber({ docNo: data["docNo"] as string }));
+      dispatch(actions.setDocNumber({ docNo: getStringValue(data["docNo"]) }));
     }
     if (data["name"] !== undefined) {
-      dispatch(actions.setGroundingName({ name: data["name"] as string }));
+      dispatch(
+        actions.setGroundingName({ name: getStringValue(data["name"]) }),
+      );
     }
     if (data["atlasType"] !== undefined) {
       dispatch(
@@ -61,7 +66,9 @@ export default function Editor(props: IProps) {
       );
     }
     if (data["content"] !== undefined) {
-      dispatch(actions.setContent({ content: data["content"] as string }));
+      dispatch(
+        actions.setContent({ content: getStringValue(data["content"]) }),
+      );
     }
     if (data["parent"] !== undefined) {
       if (data["parent"] === null) {

--- a/editors/shared/utils/utils.ts
+++ b/editors/shared/utils/utils.ts
@@ -60,13 +60,19 @@ export const fetchSelectedPHIDOption = (
 };
 
 export const getCardVariant = (mode: EditorMode) => {
-  return mode === "Edition" ? "blue" : mode === "Readonly" || mode === "DiffRemoved" ? "gray" : "green";
+  return mode === "Edition"
+    ? "blue"
+    : mode === "Readonly" || mode === "DiffRemoved"
+      ? "gray"
+      : "green";
 };
 
 export const getTagText = (mode: string) => {
-  return mode === "Edition" ? "Edition Atlas" : mode === "Readonly" || mode === "DiffRemoved"
-    ? "Official Atlas"
-    : "Atlas Draft";
+  return mode === "Edition"
+    ? "Edition Atlas"
+    : mode === "Readonly" || mode === "DiffRemoved"
+      ? "Official Atlas"
+      : "Atlas Draft";
 };
 
 // Helper function to handle null and undefined values
@@ -74,5 +80,5 @@ export const getStringValue = (value: any): string => {
   if (value === null || value === undefined) {
     return "";
   }
-  return value;
+  return value as string;
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/TYC1u6Dl/937-unified-view-edit-mode-for-atlas-foundational-and-grounding-documents

## Description
- Should allow empty in not required String fields