### PR TITLE
feat(atllas): add all field for exploratory documents

### DIFF
--- a/document-models/atlas-exploratory/src/reducers/context.ts
+++ b/document-models/atlas-exploratory/src/reducers/context.ts
@@ -8,17 +8,23 @@ import { type AtlasExploratoryContextOperations } from "../../gen/context/operat
 
 export const reducer: AtlasExploratoryContextOperations = {
   addContextDataOperation(state, action, dispatch) {
-    // TODO: Implement "addContextDataOperation" reducer
-    throw new Error('Reducer "addContextDataOperation" not yet implemented');
+  
+    state.originalContextData = state.originalContextData.filter(
+      (ocd) => ocd.id !== action.input.id,
+    );
+
+    state.originalContextData.push({
+      id: action.input.id,
+      name: action.input.name || null,
+      docNo: action.input.docNo || null,
+    });
   },
   removeContextDataOperation(state, action, dispatch) {
-    // TODO: Implement "removeContextDataOperation" reducer
-    throw new Error('Reducer "removeContextDataOperation" not yet implemented');
+    state.originalContextData = state.originalContextData.filter(
+      (ocd) => ocd.id !== action.input.id,
+    );
   },
-  setProvenanceOperation(state, action, dispatch) {
-    // TODO: Implement "setProvenanceOperation" reducer
-    throw new Error('Reducer "setProvenanceOperation" not yet implemented');
-  },
+  
   setNotionIdOperation(state, action, dispatch) {
     if (action.input.notionID) {
       state.notionId = action.input.notionID;
@@ -27,15 +33,19 @@ export const reducer: AtlasExploratoryContextOperations = {
     }
   },
   addAdditionalGuidanceOperation(state, action, dispatch) {
-    // TODO: Implement "addAdditionalGuidanceOperation" reducer
-    throw new Error(
-      'Reducer "addAdditionalGuidanceOperation" not yet implemented',
-    );
+    if (action.input.additionalGuidance) {
+      state.additionalGuidance = action.input.additionalGuidance;
+    } else {
+      throw new Error("Additional guidance missing from input.");
+    }
   },
   removeAdditionalGuidanceOperation(state, action, dispatch) {
     // TODO: Implement "removeAdditionalGuidanceOperation" reducer
     throw new Error(
       'Reducer "removeAdditionalGuidanceOperation" not yet implemented',
     );
+  },
+  setProvenanceOperation(state, action, dispatch) {
+    state.provenance = action.input.provenance || "";
   },
 };

--- a/document-models/atlas-exploratory/src/reducers/general.ts
+++ b/document-models/atlas-exploratory/src/reducers/general.ts
@@ -16,6 +16,8 @@ export const reducer: AtlasExploratoryGeneralOperations = {
   setParentOperation(state, action, dispatch) {
     // TODO: change input to singular
     //state.parent = action.input.parent?
+    state.parent = Array.isArray(action.input.parent) ? action.input.parent[0] || "" : action.input.parent || "";
+
   },
   removeParentOperation(state, action, dispatch) {
     // TODO: Implement "removeParentOperation" reducer
@@ -27,7 +29,7 @@ export const reducer: AtlasExploratoryGeneralOperations = {
   setFindingsOperation(state, action, dispatch) {
     // TODO: add comment param to input
     state.findings = {
-      comment: "",
+      comment:  "",
       isAligned: action.input.isAligned,
     };
   },

--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -1,10 +1,9 @@
 import {
   BooleanField,
+  cn,
   EnumField,
   Form,
-  PHIDField,
-  StringField,
-  UrlField,
+  PHIDField
 } from "@powerhousedao/design-system/scalars";
 import ContentCard from "../../shared/components/content-card.js";
 import {
@@ -30,6 +29,10 @@ interface ExploratoryFormProps {
   documentState: Record<string, any>;
   mode: EditorMode;
   parentPHIDInitialOption?: PHIDOption;
+  originalContextDataPHIDInitialOption?: PHIDOption;
+  referencesPHIDInitialOption?: PHIDOption;
+  isAligned?: boolean;
+
 }
 
 export function ExploratoryForm({
@@ -37,6 +40,9 @@ export function ExploratoryForm({
   documentState,
   mode,
   parentPHIDInitialOption,
+  originalContextDataPHIDInitialOption,
+  referencesPHIDInitialOption,
+  isAligned,
 }: ExploratoryFormProps) {
   const isReadOnly = isFormReadOnly(mode);
   const cardVariant = getCardVariant(mode);
@@ -56,7 +62,6 @@ export function ExploratoryForm({
       formRef.current.reset({ ...documentState });
     }
   }, [documentState]);
-
   return (
     <ContentCard tagText={tagText} variant={cardVariant} className="mt-4">
       <Form
@@ -136,32 +141,61 @@ export function ExploratoryForm({
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}
               />
+            </div>
+            {/* TODO: Improve this in next iteration */}
+            <div className="flex flex-row justify-end items-center gap-2">
+              <span className={cn(
+                !isAligned ? "text-gray-700" : "text-gray-300",
+                "text-sm font-semibold leading-[22px]"
+              )}>Misaligned</span>
               <BooleanField
                 disabled={isReadOnly}
-                name="aligned"
-                label="Aligned"
+                name="findings.isAligned"
                 isToggle
                 onChange={triggerSubmit}
               />
-              <StringDiffField
+              <span className={cn(
+                isAligned ? "text-gray-700" : "text-gray-300",
+                "text-sm font-semibold font-inter leading-[22px]"
+              )}>Aligned</span>
+            </div>
+            <StringDiffField
+              disabled={isReadOnly}
+              name="findings.comment"
+              multiline={true}
+              label="Findings"
+              placeholder="Findings"
+              onBlur={triggerSubmit}
+              mode={mode}
+              baselineValue={""} // TODO: add the right baseline value
+            />
+            <StringDiffField
+              disabled={isReadOnly}
+              name="additionalGuidance"
+              multiline={true}
+              label="Additional Guidance"
+              placeholder="Additional Guidance"
+              onBlur={triggerSubmit}
+              mode={mode}
+              baselineValue={""} // TODO: add the right baseline value
+            />
+
+            <div className="flex flex-col gap-3 w-full lg:w-1/2">
+              <PHIDField
                 disabled={isReadOnly}
-                name="findings"
-                multiline={true}
-                label="Findings"
-                placeholder="Findings"
+                name="originalContextData"
+                label="Original Context Data"
+                placeholder="phd:"
+                variant="withValueTitleAndDescription"
+                allowUris
+                initialOptions={
+                  originalContextDataPHIDInitialOption
+                    ? [originalContextDataPHIDInitialOption]
+                    : undefined
+                }
+                fetchOptionsCallback={fetchPHIDOptions}
+                fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}
-                mode={mode}
-                baselineValue={""} // TODO: add the right baseline value
-              />
-              <StringDiffField
-                disabled={isReadOnly}
-                name="additionalGuidance"
-                multiline={true}
-                label="Additional Guidance"
-                placeholder="Additional Guidance"
-                onBlur={triggerSubmit}
-                mode={mode}
-                baselineValue={""} // TODO: add the right baseline value
               />
               <UrlDiffField
                 disabled={isReadOnly}
@@ -186,7 +220,24 @@ export function ExploratoryForm({
                 mode={mode}
                 baselineValue={""} // TODO: add the right baseline value
               />
+              <PHIDField
+                disabled={isReadOnly}
+                name="references"
+                label="Atlas References"
+                placeholder="phd:"
+                variant="withValueTitleAndDescription"
+                allowUris
+                initialOptions={
+                  referencesPHIDInitialOption
+                    ? [referencesPHIDInitialOption]
+                    : undefined
+                }
+                fetchOptionsCallback={fetchPHIDOptions}
+                fetchSelectedOptionCallback={fetchSelectedPHIDOption}
+                onBlur={triggerSubmit}
+              />
             </div>
+
           </div>
         )}
       </Form>

--- a/editors/atlas-exploratory-editor/editor.tsx
+++ b/editors/atlas-exploratory-editor/editor.tsx
@@ -8,27 +8,46 @@ import {
 import { EditorLayout } from "../shared/components/EditorLayout.js";
 import { SplitView } from "../shared/components/SplitView.js";
 import { ExploratoryForm } from "./components/ExploratoryForm.js";
-import { fetchSelectedPHIDOption } from "../shared/utils/utils.js";
+import { fetchSelectedPHIDOption, getStringValue } from "../shared/utils/utils.js";
 
 export type IProps = EditorProps<AtlasExploratoryDocument>;
 
 export default function Editor(props: IProps) {
   const { dispatch } = props;
+
+  const originalDocumentState = props.document.state.global;
+
+  const parentId = originalDocumentState.parent
+    ? `phd:${originalDocumentState.parent}`
+    : "";
+  const originalContextDataId = originalDocumentState.originalContextData[0]?.id
+    ? `phd:${originalDocumentState.originalContextData[0].id}`
+    : "";
+  const referencesId = originalDocumentState.references[0]
+    ? `phd:${originalDocumentState.references[0]}`
+    : "";
+
   const documentState = {
-    ...props.document.state.global,
-    parent:
-      props.document.state.global.parent?.length > 0
-        ? `phd:${props.document.state.global.parent[0]}`
-        : "",
+    ...originalDocumentState,
+    provenance: originalDocumentState.provenance || "",
+    originalContextData: originalContextDataId,
+    references: referencesId,
+    parent: parentId,
   };
-  const parentPHIDInitialOption = fetchSelectedPHIDOption(documentState.parent);
+
+  const parentPHIDInitialOption = fetchSelectedPHIDOption(parentId);
+  const originalContextDataPHIDInitialOption = fetchSelectedPHIDOption(
+    originalContextDataId,
+  );
+  const referencesPHIDInitialOption = fetchSelectedPHIDOption(referencesId);
+  const isAligned = documentState.findings.isAligned;
 
   const onSubmit = (data: Record<string, any>) => {
     if (data["docNo"] !== undefined) {
-      dispatch(actions.setDocNumber({ docNo: data["docNo"] as string }));
+      dispatch(actions.setDocNumber({ docNo: getStringValue(data['docNo']) }));
     }
     if (data["name"] !== undefined) {
-      dispatch(actions.setExploratoryName({ name: data["name"] as string }));
+      dispatch(actions.setExploratoryName({ name: getStringValue(data["name"]) }));
     }
     if (data["masterStatus"] !== undefined) {
       dispatch(
@@ -38,18 +57,18 @@ export default function Editor(props: IProps) {
       );
     }
     if (data["content"] !== undefined) {
-      dispatch(actions.setContent({ content: data["content"] as string }));
+      dispatch(actions.setContent({ content: getStringValue(data["content"]) }));
     }
     if (data["parent"] !== undefined) {
       if (data["parent"] === null) {
         dispatch(actions.setParent({ parent: [] }));
       } else {
         const newParentId = (data["parent"] as string).split(":")[1];
+        console.log("<<first>>", newParentId)
+        
         dispatch(actions.setParent({ parent: [newParentId] }));
       }
     }
-
-    // TODO: save other fields
 
     if (data["globalTags"] !== undefined) {
       const newTags = data["globalTags"] as EGlobalTag[];
@@ -72,12 +91,53 @@ export default function Editor(props: IProps) {
         dispatch(actions.removeTags({ tags: tagsToRemove }));
       }
     }
-  };
-
+    if (data["additionalGuidance"] !== undefined) {
+      dispatch(actions.addAdditionalGuidance({ additionalGuidance: getStringValue(data["additionalGuidance"]) }));
+    }
+    if (data["originalContextData"] !== undefined) {
+      if (data["originalContextData"] === null) {
+        dispatch(
+          actions.removeContextData({
+            id: documentState.originalContextData.split(":")[1],
+          }),
+        );
+      } else {
+        const newOriginalContextDataId = (
+          data["originalContextData"] as string
+        ).split(":")[1];
+        dispatch(actions.addContextData({ id: newOriginalContextDataId }));
+      }
+    }
+    if (data["provenance"] !== undefined) {
+      dispatch(
+        actions.setProvenance({ provenance: data["provenance"] as string }),
+      );
+    }
+  // TODO: need the com
+    // if(data["findings"] !== undefined) {
+    //   dispatch(actions.setFindings({ 
+    //     isAligned: data["findings"] as boolean,
+  
+    //    }));
+    // }
+    //  TODO: add references the reference 
+    // if (data["references"] !== undefined) {
+    //   if (data["references"] === null) {
+    //     dispatch(
+    //       actions.r({
+    //         id: documentState.references.split(":")[1],
+    //       }),
+    //     );
+    //   } else {
+    //     const newReferenceId = (data["references"] as string).split(":")[1];
+    //     dispatch(actions.addReference({ id: newReferenceId }));
+    //   }
+    // }
+  }
   return (
     <EditorLayout
       title="Exploratory Document"
-      notionId={props.document.state.global.notionId}
+      notionId={documentState.notionId}
     >
       {({ isSplitMode, isEditMode }) =>
         isSplitMode ? (
@@ -88,6 +148,9 @@ export default function Editor(props: IProps) {
                 documentState={documentState}
                 mode={isEditMode ? "Edition" : "DiffRemoved"}
                 parentPHIDInitialOption={parentPHIDInitialOption}
+                originalContextDataPHIDInitialOption={originalContextDataPHIDInitialOption}
+                referencesPHIDInitialOption={referencesPHIDInitialOption}
+                isAligned={isAligned}
               />
             }
             right={
@@ -96,6 +159,9 @@ export default function Editor(props: IProps) {
                 documentState={documentState}
                 mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
                 parentPHIDInitialOption={parentPHIDInitialOption}
+                originalContextDataPHIDInitialOption={originalContextDataPHIDInitialOption}
+                referencesPHIDInitialOption={referencesPHIDInitialOption}
+                isAligned={isAligned}
               />
             }
           />
@@ -105,6 +171,9 @@ export default function Editor(props: IProps) {
             documentState={documentState}
             mode={isEditMode ? "Edition" : "Readonly"}
             parentPHIDInitialOption={parentPHIDInitialOption}
+            originalContextDataPHIDInitialOption={originalContextDataPHIDInitialOption}
+            referencesPHIDInitialOption={referencesPHIDInitialOption}
+            isAligned={isAligned}
           />
         )
       }


### PR DESCRIPTION
## Ticket
https://trello.com/c/9d8FMTjw/943-unified-view-edit-mode-for-exploratory-documents

## Description
- Should the form allow to edit the fields for each section (title, ID, bode texts, tags, etc)
- Should the editor allow to save drafts.
- Should Unified and Edit options be hardcoded. **Foundational and Grounding documents are the only ones with the toggle. The rest should show only the view/mode hardcode**