### PR TITLE
fix: save changes onBlur in Enum fields

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -94,7 +94,7 @@ export function ExploratoryForm({
                   disabled={isReadOnly}
                   label="Status"
                   name="masterStatus"
-                  onChange={triggerSubmit}
+                  onBlur={triggerSubmit}
                   options={[
                     { value: "PLACEHOLDER", label: "PLACEHOLDER" },
                     { value: "PROVISIONAL", label: "PROVISIONAL" },
@@ -181,7 +181,7 @@ export function ExploratoryForm({
                 label="Tags"
                 multiple
                 name="globalTags"
-                onChange={triggerSubmit}
+                onBlur={triggerSubmit}
                 options={globalTagsEnumOptions}
                 mode={mode}
                 baselineValue={""} // TODO: add the right baseline value

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -104,7 +104,7 @@ export function FoundationForm({
                   ]}
                   required
                   variant="Select"
-                  onChange={triggerSubmit}
+                  onBlur={triggerSubmit}
                   mode={mode}
                   baselineValue={originalNodeState.type?.toUpperCase()}
                 />
@@ -123,7 +123,7 @@ export function FoundationForm({
                   ]}
                   required
                   variant="Select"
-                  onChange={triggerSubmit}
+                  onBlur={triggerSubmit}
                   mode={mode}
                   baselineValue={originalNodeState.masterStatusNames[0]?.toUpperCase()}
                 />
@@ -196,7 +196,7 @@ export function FoundationForm({
                 options={globalTagsEnumOptions}
                 variant="Select"
                 multiple
-                onChange={triggerSubmit}
+                onBlur={triggerSubmit}
                 mode={mode}
                 baselineValue={""} // TODO: add the right baseline value
               />

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -82,7 +82,7 @@ export function GroundingForm({
                   ]}
                   required
                   variant="Select"
-                  onChange={triggerSubmit}
+                  onBlur={triggerSubmit}
                 />
               </div>
               <div className={cn("flex-1")}>
@@ -99,7 +99,7 @@ export function GroundingForm({
                   ]}
                   required
                   variant="Select"
-                  onChange={triggerSubmit}
+                  onBlur={triggerSubmit}
                 />
               </div>
             </div>
@@ -167,7 +167,7 @@ export function GroundingForm({
                 options={globalTagsEnumOptions}
                 variant="Select"
                 multiple
-                onChange={triggerSubmit}
+                onBlur={triggerSubmit}
               />
             </div>
             <div className={cn("w-1/2")}>

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -98,7 +98,7 @@ export function MultiParentForm({
                                     ]}
                                     required
                                     variant="Select"
-                                    onChange={triggerSubmit}
+                                    onBlur={triggerSubmit}
                                     mode={mode}
                                     baselineValue={originalNodeState.type?.toUpperCase()}
                                 />
@@ -108,7 +108,7 @@ export function MultiParentForm({
                                     disabled={isReadOnly}
                                     label="Status"
                                     name="masterStatus"
-                                    onChange={triggerSubmit}
+                                    onBlur={triggerSubmit}
                                     options={[
                                         { value: "PLACEHOLDER", label: "PLACEHOLDER" },
                                         { value: "PROVISIONAL", label: "PROVISIONAL" },
@@ -210,7 +210,7 @@ export function MultiParentForm({
                         <div className="w-1/2">
                             <EnumDiffField
                                 label="Tags"
-                                onChange={triggerSubmit}
+                                onBlur={triggerSubmit}
                                 multiple
                                 name="globalTags"
                                 options={globalTagsEnumOptions}

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -78,7 +78,7 @@ export function ScopeForm({ onSubmit, documentState, mode }: ScopeFormProps) {
                                 <EnumDiffField
                                     label="Status"
                                     name="masterStatus"
-                                    onChange={triggerSubmit}
+                                    onBlur={triggerSubmit}
                                     mode={mode}
                                     options={[
                                         { value: "PLACEHOLDER", label: "PLACEHOLDER" },
@@ -143,7 +143,7 @@ export function ScopeForm({ onSubmit, documentState, mode }: ScopeFormProps) {
                                     options={globalScopeTagsEnumOptions}
                                     variant="Select"
                                     multiple
-                                    onChange={triggerSubmit}
+                                    onBlur={triggerSubmit}
                                     mode={mode}
                                     // TODO: add the right baseline value
                                     baselineValue={""}


### PR DESCRIPTION
## Ticket
https://trello.com/c/HAFtVnyw/947-split-view-edit-mode-for-foundational-and-grounding-documents

## Description
- Enum-> Should save the values onblur instead of onchange