### PR TITLE
feat: add diff fields to Grounding form & preserve the originalNodeState between renders

### DIFF
--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -39,11 +39,14 @@ export function FoundationForm({
   const cardVariant = getCardVariant(mode);
   const tagText = getTagText(mode);
 
-  // baseline document state
-  const originalNodeState = getOriginalNotionDocument(
-    (documentState.notionId as string) || "notion-id-not-set",
-    (documentState.atlasType as ParsedNotionDocumentType) || "article",
+  // baseline document state, use useRef to keep the original value between renders
+  const originalNodeStateRef = useRef(
+    getOriginalNotionDocument(
+      (documentState.notionId as string) || "notion-id-not-set",
+      (documentState.atlasType as ParsedNotionDocumentType) || "article",
+    ),
   );
+  const originalNodeState = originalNodeStateRef.current;
 
   const formRef = useRef<UseFormReturn>(null);
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/HAFtVnyw/947-split-view-edit-mode-for-foundational-and-grounding-documents

## Description
- Should display a split view with two panels: an editable panel on the left and a read-only diff comparison panel on the right. (Grounding)
- Should the left panel allow to edit the fields for each section (title, ID, body texts, tags, etc). (Grounding)
- Should the right panel show the recent changes highlight differences: Red highlights for deletions, Green highlights for additions or modifications. (Grounding, in progress)
- Should the Status in the Diff panel show the previous and the new status. If new status-> also show it in the diff panel. (Grounding)
- Should the Edits made in this view be captured as document operations and logged in the revision history. (Grounding)
- Should the view allow to save drafts. (Grounding)
- Should the view validate required fields before submission. (Grounding)
- Should preserve the originalNodeState between renders (Grounding & Foundation)