### PR TITLE
fix(atlas): remove all label content

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -157,7 +157,6 @@ export function ExploratoryForm({
               disabled={isReadOnly}
               name="content"
               multiline={true}
-              label="Content"
               placeholder="Content"
               onBlur={triggerSubmit}
               mode={mode}

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -143,7 +143,6 @@ export function FoundationForm({
             </div>
             <StringDiffField
               name="content"
-              label="Content"
               placeholder="Content"
               multiline
               onBlur={triggerSubmit}

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -139,7 +139,6 @@ export function GroundingForm({
             </div>
             <StringDiffField
               name="content"
-              label="Content"
               placeholder="Content"
               multiline
               onBlur={triggerSubmit}

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -146,7 +146,6 @@ export function MultiParentForm({
               disabled={isReadOnly}
               name="content"
               multiline={true}
-              label="Content"
               placeholder="Content"
               onBlur={triggerSubmit}
               mode={mode}


### PR DESCRIPTION
## Ticket
https://trello.com/c/9d8FMTjw/943-unified-view-edit-mode-for-exploratory-documents

## Description
- Content label should not be displayed (all documents)