### PR TITLE
Fix/clear field multiparent form fix tags

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -273,7 +273,6 @@ export function ExploratoryForm({
                 label="Tags"
                 multiple
                 name="globalTags"
-                onChange={triggerSubmit}
                 options={exploratoryTagsEnumOptions}
                 onBlur={triggerSubmit}
                 mode={mode}

--- a/editors/atlas-multi-parent-editor/editor.tsx
+++ b/editors/atlas-multi-parent-editor/editor.tsx
@@ -71,7 +71,9 @@ export default function Editor(props: IProps) {
     }
     if (data["parents"] !== undefined) {
       if (data["parents"] === null) {
-        dispatch(actions.addParent({ id: "" }));
+        dispatch(actions.removeParent({ 
+          id: documentState.parents.split(":")[1],
+        }));
       } else {
         const newParentId = (data["parents"] as string).split(":")[1];
         dispatch(actions.addParent({ id: newParentId }));


### PR DESCRIPTION
Ticket
https://trello.com/c/9d8FMTjw/943-unified-view-edit-mode-for-exploratory-documents

Description
- Tags component-> several items are saving one per one in the history
- PHID-> clearing data is reflected in the history but back to the form, the data is visible again in the component (Multiparent)
