### PR TITLE
fix: add more baseline values & fix issues in Foundation & Grounding forms

### DIFF
--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -9,7 +9,6 @@ import {
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
 import type { EditorMode } from "../../shared/types.js";
 import { getOriginalNotionDocument } from "../../../document-models/utils.js";
-import { isFormReadOnly } from "../../shared/utils/form-common.js";
 import { StringDiffField } from "../../shared/components/diff-fields/string-diff-field.js";
 import { EnumDiffField } from "../../shared/components/diff-fields/enum-diff-field.js";
 import { PHIDDiffField } from "../../shared/components/diff-fields/phid-diff-field.js";
@@ -38,7 +37,6 @@ export function FoundationForm({
   referencesPHIDInitialOption,
   isSplitMode,
 }: FoundationFormProps) {
-  const isReadOnly = isFormReadOnly(mode);
   const cardVariant = getCardVariant(mode);
   const tagText = getTagText(mode);
 
@@ -49,6 +47,8 @@ export function FoundationForm({
       (documentState.atlasType as ParsedNotionDocumentType) || "article",
     ),
   );
+
+  console.log("originalNodeState", originalNodeState);
 
   const formRef = useRef<UseFormReturn>(null);
 
@@ -153,7 +153,11 @@ export function FoundationForm({
               multiline
               onBlur={triggerSubmit}
               mode={mode}
-              baselineValue={""} // TODO: add the right baseline value
+              baselineValue={
+                typeof originalNodeState.content[0].text === "string"
+                  ? originalNodeState.content[0].text
+                  : originalNodeState.content[0].text[0].plain_text
+              }
             />
             <div className={cn(isSplitMode ? "w-full" : "w-1/2")}>
               <PHIDDiffField
@@ -171,7 +175,7 @@ export function FoundationForm({
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}
                 mode={mode}
-                baselineValue={""} // TODO: add the right baseline value
+                baselineValue={originalNodeState.parents?.[0]}
               />
             </div>
             <div className={cn(isSplitMode ? "w-full" : "w-1/2")}>
@@ -204,7 +208,7 @@ export function FoundationForm({
                 }}
                 onBlur={triggerSubmit}
                 mode={mode}
-                baselineValue={""} // TODO: add the right baseline value
+                baselineValue={originalNodeState.hubUrls[0]}
               />
             </div>
             <div className={cn(isSplitMode ? "w-full" : "w-1/2")}>

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -17,8 +17,10 @@ import { type ParsedNotionDocumentType } from "../../../scripts/apply-changes/at
 import { useEffect, useRef, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { globalTagsEnumOptions } from "../../shared/utils/common-options.js";
-import { getFlexLayoutClassName, getWidthClassName } from "../../shared/utils/styles.js";
-import { PositionedWrapper } from "../../shared/components/PositionedWrapper.js";
+import {
+  getFlexLayoutClassName,
+  getWidthClassName,
+} from "../../shared/utils/styles.js";
 
 interface FoundationFormProps {
   onSubmit: (data: Record<string, any>) => void;
@@ -50,8 +52,6 @@ export function FoundationForm({
     ),
   );
 
-  console.log("originalNodeState", originalNodeState);
-
   const formRef = useRef<UseFormReturn>(null);
 
   // keep the form state in sync with the document state
@@ -74,7 +74,7 @@ export function FoundationForm({
       >
         {({ triggerSubmit }) => (
           <div className={cn("flex flex-col gap-3")}>
-            <div className={getFlexLayoutClassName(isSplitMode ?? false, )}>
+            <div className={getFlexLayoutClassName(isSplitMode ?? false)}>
               <div className={cn("flex-1")}>
                 <StringDiffField
                   name="docNo"
@@ -206,7 +206,7 @@ export function FoundationForm({
                 baselineValue={originalNodeState.hubUrls[0]}
               />
             </div>
-            <PositionedWrapper isSplitMode={isSplitMode}>
+            <div className={getWidthClassName(isSplitMode ?? false)}>
               <EnumDiffField
                 name="globalTags"
                 label="Tags"
@@ -218,7 +218,7 @@ export function FoundationForm({
                 mode={mode}
                 baselineValue={""} // TODO: add the right baseline value
               />
-            </PositionedWrapper>
+            </div>
             <div className={getWidthClassName(isSplitMode ?? false)}>
               <PHIDDiffField
                 name="references"

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -9,7 +9,6 @@ import {
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
 import type { EditorMode } from "../../shared/types.js";
 import { getOriginalNotionDocument } from "../../../document-models/utils.js";
-import { isFormReadOnly } from "../../shared/utils/form-common.js";
 import { StringDiffField } from "../../shared/components/diff-fields/string-diff-field.js";
 import { EnumDiffField } from "../../shared/components/diff-fields/enum-diff-field.js";
 import { PHIDDiffField } from "../../shared/components/diff-fields/phid-diff-field.js";
@@ -38,7 +37,6 @@ export function GroundingForm({
   referencesPHIDInitialOption,
   isSplitMode,
 }: GroundingFormProps) {
-  const isReadOnly = isFormReadOnly(mode);
   const cardVariant = getCardVariant(mode);
   const tagText = getTagText(mode);
 
@@ -149,7 +147,11 @@ export function GroundingForm({
               multiline
               onBlur={triggerSubmit}
               mode={mode}
-              baselineValue={""} // TODO: add the right baseline value
+              baselineValue={
+                typeof originalNodeState.content[0].text === "string"
+                  ? originalNodeState.content[0].text
+                  : originalNodeState.content[0].text[0].plain_text
+              }
             />
             <div className={cn(isSplitMode ? "w-full" : "w-1/2")}>
               <PHIDDiffField
@@ -167,7 +169,7 @@ export function GroundingForm({
                 fetchSelectedOptionCallback={fetchSelectedPHIDOption}
                 onBlur={triggerSubmit}
                 mode={mode}
-                baselineValue={""} // TODO: add the right baseline value
+                baselineValue={originalNodeState.parents?.[0]}
               />
             </div>
             <div className={cn(isSplitMode ? "w-full" : "w-1/2")}>
@@ -200,7 +202,7 @@ export function GroundingForm({
                 }}
                 onBlur={triggerSubmit}
                 mode={mode}
-                baselineValue={""} // TODO: add the right baseline value
+                baselineValue={originalNodeState.hubUrls[0]}
               />
             </div>
             <div className={cn(isSplitMode ? "w-full" : "w-1/2")}>

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -17,8 +17,10 @@ import { type ParsedNotionDocumentType } from "../../../scripts/apply-changes/at
 import { useEffect, useRef, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { globalTagsEnumOptions } from "../../shared/utils/common-options.js";
-import { getFlexLayoutClassName, getWidthClassName } from "../../shared/utils/styles.js";
-import { PositionedWrapper } from "../../shared/components/PositionedWrapper.js";
+import {
+  getFlexLayoutClassName,
+  getWidthClassName,
+} from "../../shared/utils/styles.js";
 
 interface GroundingFormProps {
   onSubmit: (data: Record<string, any>) => void;
@@ -93,8 +95,8 @@ export function GroundingForm({
                   baselineValue={originalNodeState.name}
                 />
               </div>
-              </div>
-              <div className={cn(getFlexLayoutClassName(isSplitMode ?? false))}>
+            </div>
+            <div className={cn(getFlexLayoutClassName(isSplitMode ?? false))}>
               <div className={cn("flex-1")}>
                 <EnumDiffField
                   name="atlasType"
@@ -200,7 +202,7 @@ export function GroundingForm({
                 baselineValue={originalNodeState.hubUrls[0]}
               />
             </div>
-           <PositionedWrapper isSplitMode={isSplitMode}>
+            <div className={cn(getWidthClassName(isSplitMode ?? false))}>
               <EnumDiffField
                 name="globalTags"
                 label="Tags"
@@ -212,7 +214,7 @@ export function GroundingForm({
                 mode={mode}
                 baselineValue={""} // TODO: add the right baseline value
               />
-            </PositionedWrapper>
+            </div>
             <div className={cn(getWidthClassName(isSplitMode ?? false))}>
               <PHIDDiffField
                 name="references"

--- a/editors/shared/components/SplitView.tsx
+++ b/editors/shared/components/SplitView.tsx
@@ -8,8 +8,8 @@ interface SplitViewProps {
 export function SplitView({ left, right }: SplitViewProps) {
   return (
     <div className="flex flex-row gap-4">
-      <div className="flex-1">{left}</div>
-      <div className="flex-1">{right}</div>
+      <div className="flex-1 max-w-1/2">{left}</div>
+      <div className="flex-1 max-w-1/2">{right}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/HAFtVnyw/947-split-view-edit-mode-for-foundational-and-grounding-documents

## Description
- Should update remaining baseline values (in progress)
- Tags component is not visible in the Split view
- Tags component-> multiple items selected, the component increases its width. 
- PHID component-> long title, the component increases its width.