### PR TITLE
fix(atlas): fix the reference and context for PHID

### DIFF
--- a/document-models/atlas-foundation/src/reducers/context.ts
+++ b/document-models/atlas-foundation/src/reducers/context.ts
@@ -1,11 +1,27 @@
 import { type AtlasFoundationContextOperations } from "../../gen/context/operations.js";
 
 export const reducer: AtlasFoundationContextOperations = {
-  addContextDataOperation(state, action, dispatch) {
-    state.originalContextData = state.originalContextData.filter(
-      (ocd) => ocd.id !== action.input.id,
-    );
+  // TODO: Implement addContextDataOperation here and in schema
+  // addContextDataOperation(state, action, dispatch) {
+  //   state.originalContextData = state.originalContextData.filter(
+  //     (ocd) => ocd.id !== action.input.id,
+  //   );
 
+  //   state.originalContextData.push({
+  //     id: action.input.id,
+  //     name: action.input.name || null,
+  //     docNo: action.input.docNo || null,
+  //   });
+  // },
+// TODO: Implement addContextDataOperation here and in schema
+  // removeContextDataOperation(state, action, dispatch) {
+  //   state.originalContextData = state.originalContextData.filter(
+  //     (ocd) => ocd.id !== action.input.id,
+  //   );
+  // }
+
+  addContextDataOperation(state, action, dispatch) {
+  
     state.originalContextData.push({
       id: action.input.id,
       name: action.input.name || null,
@@ -14,9 +30,7 @@ export const reducer: AtlasFoundationContextOperations = {
   },
 
   removeContextDataOperation(state, action, dispatch) {
-    state.originalContextData = state.originalContextData.filter(
-      (ocd) => ocd.id !== action.input.id,
-    );
+    state.originalContextData = []
   },
 
   setProvenanceOperation(state, action, dispatch) {

--- a/document-models/atlas-foundation/src/reducers/general.ts
+++ b/document-models/atlas-foundation/src/reducers/general.ts
@@ -28,20 +28,32 @@ export const reducer: AtlasFoundationGeneralOperations = {
       docNo: action.input.docNo || null,
     };
   },
+  // TODO: Implement addReferenceOperation here and in schema
+  // addReferenceOperation(state, action, dispatch) {
+  //   state.references = state.references.filter(
+  //     (ref) => ref.id !== action.input.id,
+  //   );
 
+  //   state.references.push({
+  //     id: action.input.id,
+  //     name: action.input.name || null,
+  //     docNo: action.input.docNo || null,
+  //   });
+  // },
+  // TODO: Implement removeReferenceOperation here and in schema
+    // removeReferenceOperation(state, action, dispatch) {
+  //   state.references = state.references.filter((r) => r.id !== action.input.id);
+  //   console.log("state.references", state.references);
+  // },
   addReferenceOperation(state, action, dispatch) {
-    state.references = state.references.filter(
-      (ref) => ref.id !== action.input.id,
-    );
-
-    state.references.push({
+    const newReference = {
       id: action.input.id,
       name: action.input.name || null,
       docNo: action.input.docNo || null,
-    });
+    };
+    state.references =  [...state.references,newReference];
   },
-
   removeReferenceOperation(state, action, dispatch) {
-    state.references = state.references.filter((r) => r.id !== action.input.id);
+    state.references = []
   },
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/9d8FMTjw

## Description
- Atlas references field-> adding a phd, clearing the data and selecting a new one, when click outside of the field, the old phid is displayed.