### PR TITLE
fix(atlas): truncate text for grounding and foundations docs

### DIFF
--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -75,7 +75,7 @@ export function FoundationForm({
         {({ triggerSubmit }) => (
           <div className={cn("flex flex-col gap-3")}>
             <div className={getFlexLayoutClassName(isSplitMode ?? false)}>
-              <div className={cn("flex-1")}>
+              <div className={cn("flex-1 truncate")}>
                 <StringDiffField
                   name="docNo"
                   label="Doc №"
@@ -85,7 +85,7 @@ export function FoundationForm({
                   baselineValue={originalNodeState.docNo}
                 />
               </div>
-              <div className={cn("flex-1")}>
+              <div className={cn("flex-1 truncate")}>
                 <StringDiffField
                   name="name"
                   label="Name"

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -75,7 +75,7 @@ export function GroundingForm({
         {({ triggerSubmit }) => (
           <div className={cn("flex flex-col gap-3")}>
             <div className={cn(getFlexLayoutClassName(isSplitMode ?? false))}>
-              <div className={cn("flex-1")}>
+              <div className={cn("flex-1 truncate")}>
                 <StringDiffField
                   name="docNo"
                   label="Doc №"
@@ -85,7 +85,7 @@ export function GroundingForm({
                   baselineValue={originalNodeState.docNo}
                 />
               </div>
-              <div className={cn("flex-1")}>
+              <div className={cn("flex-1 truncate")}>
                 <StringDiffField
                   name="name"
                   label="Name"


### PR DESCRIPTION
## Ticket
https://trello.com/c/9d8FMTjw/943-unified-view-edit-mode-for-exploratory-documents


## Description
-  Should the the text not over overflow the input, instead truncate 