### PR TITLE
fix: Content & Parent logic issues in Foundation & Grounding forms

### DIFF
--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -8,7 +8,10 @@ import {
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
 import type { EditorMode } from "../../shared/types.js";
-import { getOriginalNotionDocument } from "../../../document-models/utils.js";
+import {
+  getOriginalNotionDocument,
+  pndContentToString,
+} from "../../../document-models/utils.js";
 import { StringDiffField } from "../../shared/components/diff-fields/string-diff-field.js";
 import { EnumDiffField } from "../../shared/components/diff-fields/enum-diff-field.js";
 import { PHIDDiffField } from "../../shared/components/diff-fields/phid-diff-field.js";
@@ -147,11 +150,10 @@ export function FoundationForm({
               multiline
               onBlur={triggerSubmit}
               mode={mode}
-              baselineValue={
-                typeof originalNodeState.content[0]?.text === "string"
-                  ? originalNodeState.content[0]?.text
-                  : originalNodeState.content[0]?.text[0]?.plain_text
-              }
+              baselineValue={originalNodeState.content
+                .map((c) => pndContentToString(c))
+                .join("\n")
+                .trim()}
             />
             <div className={getWidthClassName(isSplitMode ?? false)}>
               <PHIDDiffField

--- a/editors/atlas-foundation-editor/editor.tsx
+++ b/editors/atlas-foundation-editor/editor.tsx
@@ -12,6 +12,8 @@ import { FoundationForm } from "./components/FoundationForm.js";
 import {
   getStringValue,
   fetchSelectedPHIDOption,
+  getTitleText,
+  parseTitleText,
 } from "../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
 
@@ -40,12 +42,13 @@ export default function Editor(props: IProps) {
     references: referencesId,
   };
   // TODO: update this with the correct data when available
+  const parentDocNo = originalDocumentState.parent?.docNo ?? "";
+  const parentName = originalDocumentState.parent?.name ?? "";
   const parentPHIDInitialOption: PHIDOption = {
     icon: "File",
-    title: `${originalDocumentState.parent?.docNo ?? ""} - ${originalDocumentState.parent?.name ?? ""}`,
+    title: getTitleText(parentDocNo, parentName),
     path: "Type not available",
     value: parentId,
-    description: undefined,
   };
   const originalContextDataPHIDInitialOption = fetchSelectedPHIDOption(
     originalContextDataId,
@@ -86,11 +89,12 @@ export default function Editor(props: IProps) {
       } else {
         const newParentId = (data["parent"] as string).split(":")[1];
         const newParentData = fetchSelectedPHIDOption(data["parent"] as string);
+        const { docNo, name } = parseTitleText(newParentData?.title ?? "");
         dispatch(
           actions.setParent({
             id: newParentId,
-            docNo: newParentData?.title?.split(" - ")[0] ?? "",
-            name: newParentData?.title?.split(" - ")[1] ?? "",
+            docNo,
+            name,
           }),
         );
       }

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -8,7 +8,10 @@ import {
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
 import type { EditorMode } from "../../shared/types.js";
-import { getOriginalNotionDocument } from "../../../document-models/utils.js";
+import {
+  getOriginalNotionDocument,
+  pndContentToString,
+} from "../../../document-models/utils.js";
 import { StringDiffField } from "../../shared/components/diff-fields/string-diff-field.js";
 import { EnumDiffField } from "../../shared/components/diff-fields/enum-diff-field.js";
 import { PHIDDiffField } from "../../shared/components/diff-fields/phid-diff-field.js";
@@ -143,11 +146,10 @@ export function GroundingForm({
               multiline
               onBlur={triggerSubmit}
               mode={mode}
-              baselineValue={
-                typeof originalNodeState.content[0]?.text === "string"
-                  ? originalNodeState.content[0]?.text
-                  : originalNodeState.content[0]?.text[0]?.plain_text
-              }
+              baselineValue={originalNodeState.content
+                .map((c) => pndContentToString(c))
+                .join("\n")
+                .trim()}
             />
             <div className={cn(getWidthClassName(isSplitMode ?? false))}>
               <PHIDDiffField

--- a/editors/atlas-grounding-editor/editor.tsx
+++ b/editors/atlas-grounding-editor/editor.tsx
@@ -12,6 +12,8 @@ import { GroundingForm } from "./components/GroundingForm.js";
 import {
   getStringValue,
   fetchSelectedPHIDOption,
+  getTitleText,
+  parseTitleText,
 } from "../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
 
@@ -40,12 +42,13 @@ export default function Editor(props: IProps) {
     references: referencesId,
   };
   // TODO: update this with the correct data when available
+  const parentDocNo = originalDocumentState.parent?.docNo ?? "";
+  const parentName = originalDocumentState.parent?.name ?? "";
   const parentPHIDInitialOption: PHIDOption = {
     icon: "File",
-    title: `${originalDocumentState.parent?.docNo ?? ""} - ${originalDocumentState.parent?.name ?? ""}`,
+    title: getTitleText(parentDocNo, parentName),
     path: "Type not available",
     value: parentId,
-    description: undefined,
   };
   const originalContextDataPHIDInitialOption = fetchSelectedPHIDOption(
     originalContextDataId,
@@ -86,11 +89,12 @@ export default function Editor(props: IProps) {
       } else {
         const newParentId = (data["parent"] as string).split(":")[1];
         const newParentData = fetchSelectedPHIDOption(data["parent"] as string);
+        const { docNo, name } = parseTitleText(newParentData?.title ?? "");
         dispatch(
           actions.setParent({
             id: newParentId,
-            docNo: newParentData?.title?.split(" - ")[0] ?? "",
-            name: newParentData?.title?.split(" - ")[1] ?? "",
+            docNo,
+            name,
           }),
         );
       }

--- a/editors/shared/components/diff-fields/phid-diff-field.tsx
+++ b/editors/shared/components/diff-fields/phid-diff-field.tsx
@@ -51,8 +51,8 @@ const PHIDDiffField = ({
         <div className={cn("absolute top-0 left-0 right-0 z-10 w-full")}>
           <FakeInput>
             <DiffText
-              baseline={baselineValue}
-              value={currentValue}
+              baseline={baselineValue.replace(/phd:|phd:\/\//, "")}
+              value={currentValue.replace(/phd:|phd:\/\//, "")}
               mode={mode}
               diffMode={diffMode}
             />

--- a/editors/shared/utils/utils.ts
+++ b/editors/shared/utils/utils.ts
@@ -86,7 +86,29 @@ export const getStringValue = (value: any): string => {
 
 export const getRemoteDriveUrl = (drive: DocumentDriveDocument) => {
   const trigger = drive.state.local.triggers.find(
-    trigger => trigger.data?.url,
+    (trigger) => trigger.data?.url,
   );
-  return  trigger?.data?.url || null;
-}
+  return trigger?.data?.url || null;
+};
+
+export const getTitleText = (docNo: string, name: string) => {
+  if (docNo !== "" && name !== "") {
+    return `${docNo} - ${name}`;
+  }
+  if (docNo !== "" && name === "") {
+    return docNo;
+  }
+  if (docNo === "" && name !== "") {
+    return name;
+  }
+  return "Title not available";
+};
+
+export const parseTitleText = (title: string) => {
+  if (title === "") return { docNo: "", name: "" };
+  if (title.includes(" - ")) {
+    const parts = title.split(" - ");
+    return { docNo: parts[0], name: parts[1] };
+  }
+  return { docNo: "", name: title };
+};


### PR DESCRIPTION
## Ticket
https://trello.com/c/HAFtVnyw/947-split-view-edit-mode-for-foundational-and-grounding-documents

## Description
- PHID: In the diff comparison  a "-" is displayed as part of the differences.
- PHID: In the diff comparison, the protocol should not be included because this info is not coming from the data at this moment.
- Textarea (content section): the field displays only a part of the content while from the data is coming additional info for this field.