### PR TITLE
fix: show the correct view mode after close the revision history

### DIFF
--- a/editors/drive-explorer/components/EditorContainer.tsx
+++ b/editors/drive-explorer/components/EditorContainer.tsx
@@ -15,6 +15,7 @@ import {
   DefaultEditorLoader,
 } from "@powerhousedao/design-system";
 import { useState, Suspense, type FC, useCallback, lazy } from "react";
+import { ViewModeProvider } from "../../shared/context/view-mode-context.js";
 
 import {
   AtlasExploratory,
@@ -88,6 +89,7 @@ export const EditorContainer: React.FC<EditorContainerProps> = (props) => {
   const { driveId, documentId, documentType, onClose, title, context } = props;
 
   const [showRevisionHistory, setShowRevisionHistory] = useState(false);
+
   const { useDocumentEditorProps } = useDriveContext();
   const user = context.user as User | undefined;
 
@@ -130,30 +132,34 @@ export const EditorContainer: React.FC<EditorContainerProps> = (props) => {
   }
   const EditorComponent = Editor as FC<EditorProps<PHDocument>>;
 
-  return showRevisionHistory ? (
-    <RevisionHistory
-      documentId={documentId}
-      documentTitle={title}
-      globalOperations={document.operations.global}
-      key={documentId}
-      localOperations={document.operations.local}
-      onClose={() => setShowRevisionHistory(false)}
-    />
-  ) : (
-    <Suspense fallback={loadingContent}>
-      <DocumentToolbar
-        onClose={onClose}
-        onExport={onExport}
-        onShowRevisionHistory={() => setShowRevisionHistory(true)}
-        onSwitchboardLinkClick={() => {}}
-        title={title}
-      />
-      <EditorComponent
-        context={context}
-        dispatch={dispatch}
-        document={document}
-        error={error}
-      />
-    </Suspense>
+  return (
+    <ViewModeProvider>
+      {showRevisionHistory ? (
+        <RevisionHistory
+          documentId={documentId}
+          documentTitle={title}
+          globalOperations={document.operations.global}
+          key={documentId}
+          localOperations={document.operations.local}
+          onClose={() => setShowRevisionHistory(false)}
+        />
+      ) : (
+        <Suspense fallback={loadingContent}>
+          <DocumentToolbar
+            onClose={onClose}
+            onExport={onExport}
+            onShowRevisionHistory={() => setShowRevisionHistory(true)}
+            onSwitchboardLinkClick={() => {}}
+            title={title}
+          />
+          <EditorComponent
+            context={context}
+            dispatch={dispatch}
+            document={document}
+            error={error}
+          />
+        </Suspense>
+      )}
+    </ViewModeProvider>
   );
 };

--- a/editors/shared/components/EditorLayout.tsx
+++ b/editors/shared/components/EditorLayout.tsx
@@ -4,6 +4,7 @@ import type { Maybe } from "document-model";
 import { useSidebar, type SidebarNode } from "@powerhousedao/design-system/ui";
 import { Breadcrumbs } from "./breadcrumbs.js";
 import { cn } from "@powerhousedao/design-system/scalars";
+import { useViewMode } from "../context/view-mode-context.js";
 
 export type ChildrenFn = ({
   isSplitMode,
@@ -28,8 +29,8 @@ export const EditorLayout = ({
   splitModeEnabled = false,
   readOnlyModeEnabled = false,
 }: EditorLayoutProps) => {
-  const [isSplitMode, setIsSplitMode] = useState<boolean>(false);
-  const [isEditMode, setIsEditMode] = useState<boolean>(true);
+  const { isSplitMode, setIsSplitMode, isEditMode, setIsEditMode } =
+    useViewMode();
 
   const { nodes, activeNodeId, onActiveNodeChange } = useSidebar();
 

--- a/editors/shared/context/view-mode-context.tsx
+++ b/editors/shared/context/view-mode-context.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, type ReactNode, useState } from "react";
+
+// context type
+export type ViewModeContextType = {
+  isSplitMode: boolean;
+  setIsSplitMode: (value: boolean) => void;
+  isEditMode: boolean;
+  setIsEditMode: (value: boolean) => void;
+};
+
+// context
+export const ViewModeContext = createContext<ViewModeContextType | null>(null);
+
+// context hook
+export const useViewMode = () => {
+  const context = useContext(ViewModeContext);
+  if (!context) {
+    throw new Error("useViewMode must be used within ViewModeProvider");
+  }
+  return context;
+};
+
+// provider props
+interface ViewModeProviderProps {
+  children: ReactNode;
+}
+
+export const ViewModeProvider = ({ children }: ViewModeProviderProps) => {
+  // provider states
+  const [isSplitMode, setIsSplitMode] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(true);
+
+  // provider value
+  const value = {
+    isSplitMode,
+    setIsSplitMode,
+    isEditMode,
+    setIsEditMode,
+  };
+
+  // provider
+  return (
+    <ViewModeContext.Provider value={value}>
+      {children}
+    </ViewModeContext.Provider>
+  );
+};


### PR DESCRIPTION
## Ticket
https://trello.com/c/HAFtVnyw/947-split-view-edit-mode-for-foundational-and-grounding-documents

## Description
- Split view. Go to the history and get back to the forms. The split view, the current view where you was before go to the history, should be displayed