### PR TITLE
feat: save data if changed when clicking on the refetch icon in single PHID-based fields

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -165,7 +165,7 @@ export function ExploratoryForm({
               value={documentState.parent}
               baselineValue={""}
               onSave={(value) => {
-                if (value === null) {
+                if (value === null || value === "") {
                   dispatch(actions.setParent({ parent: "" }));
                 } else {
                   const newParentId = value.split(":")[1];

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -162,7 +162,7 @@ export function FoundationForm({
               value={documentState.parent}
               baselineValue={originalNodeState.parents?.[0] ?? ""}
               onSave={(value) => {
-                if (value === null) {
+                if (value === null || value === "") {
                   dispatch(
                     actions.setParent({
                       id: "",

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -173,7 +173,7 @@ export function GroundingForm({
               value={documentState.parent}
               baselineValue={originalNodeState.parents?.[0] ?? ""}
               onSave={(value) => {
-                if (value === null) {
+                if (value === null || value === "") {
                   dispatch(
                     actions.setParent({
                       id: "",

--- a/editors/shared/components/forms/generics/GenericPHIDForm.tsx
+++ b/editors/shared/components/forms/generics/GenericPHIDForm.tsx
@@ -1,6 +1,5 @@
 import { Form } from "@powerhousedao/design-system/scalars";
 import { useFormMode } from "../../../providers/FormModeProvider.js";
-import { StringDiffField } from "../../diff-fields/string-diff-field.js";
 import { PHIDDiffField } from "../../diff-fields/phid-diff-field.js";
 import {
   fetchPHIDOptions,
@@ -50,7 +49,20 @@ const GenericPHIDForm = ({
           allowUris
           initialOptions={initialOptions}
           fetchOptionsCallback={fetchPHIDOptions}
-          fetchSelectedOptionCallback={fetchSelectedPHIDOption}
+          fetchSelectedOptionCallback={(val) => {
+            const result = fetchSelectedPHIDOption(val);
+            if (result !== undefined) {
+              if (
+                result.value !== value ||
+                result.title !== initialOptions?.[0].title
+              ) {
+                onSave(result.value);
+              }
+            } else if (value !== "") {
+              onSave("");
+            }
+            return result;
+          }}
           onBlur={triggerSubmit}
           mode={formMode}
           baselineValue={baselineValue}


### PR DESCRIPTION
## Ticket
https://trello.com/c/K4chsAuc/976-unified-edit-views-pending-issues-reqs

## Description
- PHID: clicking on the refresh icon, the data should be reloaded and saved if changed (Single PHID-based fields)