### PR TITLE
feat: save data if changed when clicking on the refetch icon in multi PHID based fields

### DIFF
--- a/editors/shared/components/forms/MultiPhIdForm.tsx
+++ b/editors/shared/components/forms/MultiPhIdForm.tsx
@@ -61,7 +61,34 @@ const MultiPhIdForm = ({
         variant: "withValueAndTitle",
         allowUris: true,
         fetchOptionsCallback: fetchPHIDOptions,
-        fetchSelectedOptionCallback: fetchSelectedPHIDOption,
+        fetchSelectedOptionCallback: (val) => {
+          const result = fetchSelectedPHIDOption(val);
+          const element = data.find((d) => d.id === val);
+          const elementIndex = data.findIndex((d) => d.id === val);
+
+          if (element !== undefined) {
+            if (result !== undefined) {
+              if (
+                result.value !== element.id ||
+                result.title !== element.initialOptions?.[0]?.title
+              ) {
+                onUpdate({
+                  previousValue: element.id,
+                  value: result.value,
+                  id: element.id,
+                  index: elementIndex,
+                });
+              }
+            } else if (element.id !== "") {
+              onRemove({
+                value: element.id,
+                id: element.id,
+                index: elementIndex,
+              });
+            }
+          }
+          return result;
+        },
         mode: formMode,
         validators: [
           (value: string, formState) => {


### PR DESCRIPTION
## Ticket
https://trello.com/c/K4chsAuc/976-unified-edit-views-pending-issues-reqs

## Description
- PHID: clicking on the refresh icon, the data should be reloaded and saved if changed (Multi PHID based fields)