### PR TITLE
fix: avoid to remove data when refetch in PHID-based fields

### DIFF
--- a/editors/shared/components/forms/MultiPhIdForm.tsx
+++ b/editors/shared/components/forms/MultiPhIdForm.tsx
@@ -66,28 +66,21 @@ const MultiPhIdForm = ({
           const element = data.find((d) => d.id === val);
           const elementIndex = data.findIndex((d) => d.id === val);
 
-          if (element !== undefined) {
-            if (result !== undefined) {
-              if (
-                result.value !== element.id ||
-                result.title !== element.initialOptions?.[0]?.title
-              ) {
-                onUpdate({
-                  previousValue: element.id,
-                  value: result.value,
-                  id: element.id,
-                  index: elementIndex,
-                });
-              }
-            } else if (element.id !== "") {
-              onRemove({
-                value: element.id,
-                id: element.id,
-                index: elementIndex,
-              });
-            }
+          if (
+            result !== undefined &&
+            element !== undefined &&
+            (result.value !== element.id ||
+              result.title !== element.initialOptions?.[0]?.title)
+          ) {
+            onUpdate({
+              previousValue: element.id,
+              value: result.value,
+              id: element.id,
+              index: elementIndex,
+            });
+            return result;
           }
-          return result;
+          return element?.initialOptions?.[0];
         },
         mode: formMode,
         validators: [

--- a/editors/shared/components/forms/generics/GenericPHIDForm.tsx
+++ b/editors/shared/components/forms/generics/GenericPHIDForm.tsx
@@ -51,17 +51,15 @@ const GenericPHIDForm = ({
           fetchOptionsCallback={fetchPHIDOptions}
           fetchSelectedOptionCallback={(val) => {
             const result = fetchSelectedPHIDOption(val);
-            if (result !== undefined) {
-              if (
-                result.value !== value ||
-                result.title !== initialOptions?.[0].title
-              ) {
-                onSave(result.value);
-              }
-            } else if (value !== "") {
-              onSave("");
+            if (
+              result !== undefined &&
+              (result.value !== value ||
+                result.title !== initialOptions?.[0].title)
+            ) {
+              onSave(result.value);
+              return result;
             }
-            return result;
+            return initialOptions?.[0];
           }}
           onBlur={triggerSubmit}
           mode={formMode}


### PR DESCRIPTION
## Ticket
https://trello.com/c/K4chsAuc/976-unified-edit-views-pending-issues-reqs

## Description
- PHID: clicking on the refresh icon, the data should be reloaded and saved if changed (All PHID based fields)