### PR TITLE
fix(atlas): add min-height to avoid jump

### DIFF
--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -142,14 +142,15 @@ export function FoundationForm({
               />
             </div>
           </div>
-
-          <MarkdownEditor
-            value={contentValue}
-            onChange={handleContentChange}
-            onBlur={handleContentBlur}
-            height={350}
-            label="Content"
-          />
+          <div className={cn("flex-1 min-h-[350px]")}>
+            <MarkdownEditor
+              value={contentValue}
+              onChange={handleContentChange}
+              onBlur={handleContentBlur}
+              height={350}
+              label="Content"
+            />
+          </div>
 
           <div
             className={cn(

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -153,14 +153,15 @@ export function GroundingForm({
               />
             </div>
           </div>
-
-          <MarkdownEditor
-            value={contentValue}
-            onChange={handleContentChange}
-            onBlur={handleContentBlur}
-            height={350}
-            label="Content"
-          />
+          <div className={cn("flex-1 min-h-[350px]")}>
+            <MarkdownEditor
+              value={contentValue}
+              onChange={handleContentChange}
+              onBlur={handleContentBlur}
+              height={350}
+              label="Content"
+            />
+          </div>
 
           <div
             className={cn(

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -118,14 +118,15 @@ export function MultiParentForm({
               />
             </div>
           </div>
-
-          <MarkdownEditor
-            value={contentValue}
-            onChange={handleContentChange}
-            onBlur={handleContentBlur}
-            height={350}
-            label="Content"
-          />
+          <div className={cn("flex-1 min-h-[350px]")}>
+            <MarkdownEditor
+              value={contentValue}
+              onChange={handleContentChange}
+              onBlur={handleContentBlur}
+              height={350}
+              label="Content"
+            />
+          </div>
 
           <div
             className={cn(

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -14,7 +14,6 @@ import {
   getFlexLayoutClassName,
   getWidthClassName,
 } from "../../shared/utils/styles.js";
-import { PositionedWrapper } from "../../shared/components/PositionedWrapper.js";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
 import { DocNoForm } from "../../shared/components/forms/DocNoForm.js";
 import type { IProps } from "../editor.js";
@@ -120,14 +119,15 @@ export function ScopeForm({
               />
             </div>
           </div>
-
-          <MarkdownEditor
-            value={contentValue}
-            onChange={handleContentChange}
-            onBlur={handleContentBlur}
-            height={350}
-            label="Content"
-          />
+          <div className={cn("flex-1 min-h-[350px]")}>
+            <MarkdownEditor
+              value={contentValue}
+              onChange={handleContentChange}
+              onBlur={handleContentBlur}
+              height={350}
+              label="Content"
+            />
+          </div>
 
           <div className={cn("flex flex-col gap-4")}>
             <div className={cn(getWidthClassName(isSplitMode ?? false))}>

--- a/editors/atlas-scope-editor/editor.tsx
+++ b/editors/atlas-scope-editor/editor.tsx
@@ -35,7 +35,7 @@ export default function Editor(props: IProps) {
           <ScopeForm
             document={props.document}
             dispatch={props.dispatch}
-            mode={isEditMode ? "Edition" : "Readonly"}
+            mode={isEditMode ? "Edition" : "DiffMixed"}
           />
         )
       }


### PR DESCRIPTION
## Ticket
https://trello.com/c/K4chsAuc/976-unified-edit-views-pending-issues-reqs

## Description
- From the history view, going back to the form, the Content section is visible after a few seconds causing the PHDs section to jump up and down.