### PR TITLE
fix(atlas): add makdonw styles in root file

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 @import url("@powerhousedao/design-system/style.css");
 @import "tailwindcss" source(".");
+@import "./editors/shared/components/markdown-editor.module.css";
 
 @layer base {
   .atlas-drive-explorer h1,


### PR DESCRIPTION
## Ticket
https://trello.com/c/2LUrNgnQ/994-release-to-staging-atlas-dmeditor-05-05-25

## Description
This relative .css import fails because the .css files don't get moved to the /dist folder on pnpm build.