### PR TITLE
fix(atlas): remove the file as its import in global

### DIFF
--- a/editors/shared/components/markdown-editor.tsx
+++ b/editors/shared/components/markdown-editor.tsx
@@ -5,7 +5,6 @@ import "@uiw/react-md-editor/markdown-editor.css";
 // import "@uiw/react-markdown-preview/markdown.css";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
-import "./markdown-editor.module.css";
 
 // Custom preview renderer to make links open in new tabs and ensure proper list rendering
 const previewOptions = {


### PR DESCRIPTION
## Ticket
https://trello.com/c/2LUrNgnQ/994-release-to-staging-atlas-dmeditor-05-05-25

## Description
This relative .css import fails because the .css files don't get moved to the /dist folder on pnpm build. [image.png](https://trello.com/1/cards/6818bf31629f4eac163352d5/attachments/6819eb3a175c9522b73626a4/download/image.png)