### PR TITLE
fix(atlas): fix the null values in name mandatory field

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -3,6 +3,7 @@ import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
   getCardVariant,
+  getStringValue,
   getTagText,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
@@ -112,7 +113,11 @@ export function ExploratoryForm({
                 value={documentState.name}
                 baselineValue={originalNodeState.name}
                 onSave={(value) => {
-                  dispatch(actions.setExploratoryName({ name: value ?? "" }));
+                  dispatch(
+                    actions.setExploratoryName({
+                      name: getStringValue(value),
+                    }),
+                  );
                 }}
               />
             </div>

--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -112,7 +112,7 @@ export function ExploratoryForm({
                 value={documentState.name}
                 baselineValue={originalNodeState.name}
                 onSave={(value) => {
-                  dispatch(actions.setExploratoryName({ name: value }));
+                  dispatch(actions.setExploratoryName({ name: value ?? "" }));
                 }}
               />
             </div>

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -3,6 +3,7 @@ import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
   getCardVariant,
+  getStringValue,
   getTagText,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
@@ -117,7 +118,11 @@ export function FoundationForm({
                 value={documentState.name}
                 baselineValue={originalNodeState.name}
                 onSave={(value) => {
-                  dispatch(actions.setFoundationName({ name: value }));
+                  dispatch(
+                    actions.setFoundationName({
+                      name: getStringValue(value),
+                    }),
+                  );
                 }}
               />
             </div>

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -3,6 +3,7 @@ import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
   getCardVariant,
+  getStringValue,
   getTagText,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/design-system/ui";
@@ -118,7 +119,11 @@ export function GroundingForm({
                 value={documentState.name}
                 baselineValue={originalNodeState.name}
                 onSave={(value) => {
-                  dispatch(actions.setGroundingName({ name: value }));
+                  dispatch(
+                    actions.setGroundingName({
+                      name: getStringValue(value),
+                    }),
+                  );
                 }}
               />
             </div>

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -3,6 +3,7 @@ import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
   getCardVariant,
+  getStringValue,
   getTagText,
 } from "../../shared/utils/utils.js";
 import type { EditorMode } from "../../shared/types.js";
@@ -102,7 +103,9 @@ export function ScopeForm({
                 value={documentState.name}
                 baselineValue={originalNodeState.name}
                 onSave={(value) => {
-                  dispatch(actions.setScopeName({ name: value }));
+                  dispatch(
+                    actions.setScopeName({ name: getStringValue(value) }),
+                  );
                 }}
                 placeholder="The Governance Scope"
               />

--- a/editors/atlas-set-editor/components/SetForm.tsx
+++ b/editors/atlas-set-editor/components/SetForm.tsx
@@ -9,6 +9,7 @@ import { getFlexLayoutClassName } from "../../shared/utils/styles.js";
 import {
   fetchSelectedPHIDOption,
   getCardVariant,
+  getStringValue,
   getTagText,
 } from "../../shared/utils/utils.js";
 import { type IProps } from "../editor.js";
@@ -57,7 +58,7 @@ export function SetForm({
                 value={documentState.name}
                 baselineValue={originalNodeState.name}
                 onSave={(value) => {
-                  dispatch(actions.setSetName({ name: value }));
+                  dispatch(actions.setSetName({ name: getStringValue(value) }));
                 }}
                 placeholder="The Governance Scope"
               />


### PR DESCRIPTION
## Ticket
https://trello.com/c/X10a3hCg/989-add-the-read-only-diff-status-for-the-strings-to-the-document-types

## Description
- Foundation doc. Name field. Removing the name value. **Expected Output:** The field should allow empty values. **Current Output:** The "Expected string, received null" error message appears above the field. 