### PR TITLE
fix(atlas): add same type in all form

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@powerhousedao/document-engineering/scalars";
+import { cn, type ViewMode } from "@powerhousedao/document-engineering/scalars";
 import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
@@ -36,7 +36,7 @@ import {
 } from "../../shared/utils/styles.js";
 
 interface ExploratoryFormProps extends Pick<IProps, "document" | "dispatch"> {
-  mode: EditorMode;
+  mode: ViewMode;
   isSplitMode?: boolean;
   isAligned?: boolean;
 }
@@ -214,7 +214,7 @@ export function ExploratoryForm({
               Misaligned
             </span>
             <Toggle
-              disabled={mode !== "Edition"}
+              disabled={mode !== "edition"}
               name="findings.isAligned"
               value={documentState.findings.isAligned}
               onChange={() => {

--- a/editors/atlas-exploratory-editor/editor.tsx
+++ b/editors/atlas-exploratory-editor/editor.tsx
@@ -25,7 +25,7 @@ export default function Editor(props: IProps) {
                 document={props.document}
                 dispatch={props.dispatch}
                 isSplitMode={isSplitMode}
-                mode={isEditMode ? "Edition" : "DiffRemoved"}
+                mode={isEditMode ? "edition" : "removal"}
                 isAligned={isAligned}
               />
             }
@@ -34,7 +34,7 @@ export default function Editor(props: IProps) {
                 document={props.document}
                 dispatch={props.dispatch}
                 isSplitMode={isSplitMode}
-                mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
+                mode={isEditMode ? "mixed" : "addition"}
                 isAligned={isAligned}
               />
             }
@@ -43,7 +43,7 @@ export default function Editor(props: IProps) {
           <ExploratoryForm
             document={props.document}
             dispatch={props.dispatch}
-            mode={isEditMode ? "Edition" : "DiffMixed"}
+            mode={isEditMode ? "edition" : "mixed"}
             isAligned={isAligned}
           />
         )

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@powerhousedao/document-engineering/scalars";
+import { cn, type ViewMode } from "@powerhousedao/document-engineering/scalars";
 import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
@@ -7,7 +7,6 @@ import {
   getTagText,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";
-import type { EditorMode } from "../../shared/types.js";
 import { getOriginalNotionDocument } from "../../../document-models/utils.js";
 import { type ParsedNotionDocumentType } from "../../../scripts/apply-changes/atlas-base/NotionTypes.js";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
@@ -31,7 +30,7 @@ import { MarkdownEditor } from "../../shared/components/markdown-editor.js";
 import { MultiPhIdForm } from "../../shared/components/forms/MultiPhIdForm.js";
 
 interface FoundationFormProps extends Pick<IProps, "document" | "dispatch"> {
-  mode: EditorMode;
+  mode: ViewMode;
   isSplitMode?: boolean;
 }
 

--- a/editors/atlas-foundation-editor/editor.tsx
+++ b/editors/atlas-foundation-editor/editor.tsx
@@ -22,7 +22,7 @@ export default function Editor(props: IProps) {
                 document={props.document}
                 dispatch={props.dispatch}
                 isSplitMode={isSplitMode}
-                mode={isEditMode ? "Edition" : "DiffRemoved"}
+                mode={isEditMode ? "edition" : "removal"}
               />
             }
             right={
@@ -30,7 +30,7 @@ export default function Editor(props: IProps) {
                 document={props.document}
                 dispatch={props.dispatch}
                 isSplitMode={isSplitMode}
-                mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
+                mode={isEditMode ? "mixed" : "addition"}
               />
             }
           />
@@ -38,7 +38,7 @@ export default function Editor(props: IProps) {
           <FoundationForm
             document={props.document}
             dispatch={props.dispatch}
-            mode={isEditMode ? "Edition" : "DiffMixed"}
+            mode={isEditMode ? "edition" : "mixed"}
           />
         )
       }

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@powerhousedao/document-engineering/scalars";
+import { cn, type ViewMode } from "@powerhousedao/document-engineering/scalars";
 import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
@@ -32,7 +32,7 @@ import { MarkdownEditor } from "../../shared/components/markdown-editor.js";
 import { MultiPhIdForm } from "../../shared/components/forms/MultiPhIdForm.js";
 
 interface GroundingFormProps extends Pick<IProps, "document" | "dispatch"> {
-  mode: EditorMode;
+  mode: ViewMode;
   isSplitMode?: boolean;
 }
 

--- a/editors/atlas-grounding-editor/editor.tsx
+++ b/editors/atlas-grounding-editor/editor.tsx
@@ -22,7 +22,7 @@ export default function Editor(props: IProps) {
                 document={props.document}
                 dispatch={props.dispatch}
                 isSplitMode={isSplitMode}
-                mode={isEditMode ? "Edition" : "DiffRemoved"}
+                mode={isEditMode ? "edition" : "removal"}
               />
             }
             right={
@@ -30,7 +30,7 @@ export default function Editor(props: IProps) {
                 document={props.document}
                 dispatch={props.dispatch}
                 isSplitMode={isSplitMode}
-                mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
+                mode={isEditMode ? "mixed" : "addition"}
               />
             }
           />
@@ -38,7 +38,7 @@ export default function Editor(props: IProps) {
           <GroundingForm
             document={props.document}
             dispatch={props.dispatch}
-            mode={isEditMode ? "Edition" : "DiffMixed"}
+            mode={isEditMode ? "edition" : "mixed"}
           />
         )
       }

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@powerhousedao/document-engineering/scalars";
+import { cn, type ViewMode } from "@powerhousedao/document-engineering/scalars";
 import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
@@ -30,7 +30,7 @@ import { MultiPhIdForm } from "../../shared/components/forms/MultiPhIdForm.js";
 import type { PHIDOption } from "@powerhousedao/document-engineering/ui";
 
 interface MultiParentFormProps extends Pick<IProps, "document" | "dispatch"> {
-  mode: EditorMode;
+  mode: ViewMode;
   isSplitMode?: boolean;
 }
 

--- a/editors/atlas-multi-parent-editor/editor.tsx
+++ b/editors/atlas-multi-parent-editor/editor.tsx
@@ -22,7 +22,7 @@ export default function Editor(props: IProps) {
                 document={props.document}
                 dispatch={props.dispatch}
                 isSplitMode={isSplitMode}
-                mode={isEditMode ? "Edition" : "DiffRemoved"}
+                mode={isEditMode ? "edition" : "removal"}
               />
             }
             right={
@@ -30,7 +30,7 @@ export default function Editor(props: IProps) {
                 document={props.document}
                 dispatch={props.dispatch}
                 isSplitMode={isSplitMode}
-                mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
+                mode={isEditMode ? "mixed" : "addition"}
               />
             }
           />
@@ -38,7 +38,7 @@ export default function Editor(props: IProps) {
           <MultiParentForm
             document={props.document}
             dispatch={props.dispatch}
-            mode={isEditMode ? "Edition" : "DiffMixed"}
+            mode={isEditMode ? "edition" : "mixed"}
           />
         )
       }

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@powerhousedao/document-engineering/scalars";
+import { cn, type ViewMode } from "@powerhousedao/document-engineering/scalars";
 import ContentCard from "../../shared/components/content-card.js";
 import {
   fetchSelectedPHIDOption,
@@ -30,7 +30,7 @@ import { MultiPhIdForm } from "../../shared/components/forms/MultiPhIdForm.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";
 
 interface ScopeFormProps extends Pick<IProps, "document" | "dispatch"> {
-  mode: EditorMode;
+  mode: ViewMode;
   isSplitMode?: boolean;
 }
 

--- a/editors/atlas-scope-editor/editor.tsx
+++ b/editors/atlas-scope-editor/editor.tsx
@@ -20,7 +20,7 @@ export default function Editor(props: IProps) {
               <ScopeForm
                 document={props.document}
                 dispatch={props.dispatch}
-                mode={isEditMode ? "Edition" : "DiffRemoved"}
+                mode={isEditMode ? "edition" : "removal"}
                 isSplitMode={isSplitMode}
               />
             }
@@ -28,7 +28,7 @@ export default function Editor(props: IProps) {
               <ScopeForm
                 document={props.document}
                 dispatch={props.dispatch}
-                mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
+                mode={isEditMode ? "mixed" : "addition"}
                 isSplitMode={isSplitMode}
               />
             }
@@ -37,7 +37,7 @@ export default function Editor(props: IProps) {
           <ScopeForm
             document={props.document}
             dispatch={props.dispatch}
-            mode={isEditMode ? "Edition" : "DiffMixed"}
+            mode={isEditMode ? "edition" : "mixed"}
           />
         )
       }

--- a/editors/atlas-set-editor/components/SetForm.tsx
+++ b/editors/atlas-set-editor/components/SetForm.tsx
@@ -1,10 +1,9 @@
-import { cn } from "@powerhousedao/document-engineering/scalars";
+import { cn, type ViewMode } from "@powerhousedao/document-engineering/scalars";
 import { actions } from "../../../document-models/atlas-set/index.js";
 import ContentCard from "../../shared/components/content-card.js";
 import { DocNameForm } from "../../shared/components/forms/DocNameForm.js";
 import { SinglePhIdForm } from "../../shared/components/forms/SinglePhIdForm.js";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
-import { type EditorMode } from "../../shared/types.js";
 import { getFlexLayoutClassName } from "../../shared/utils/styles.js";
 import {
   fetchSelectedPHIDOption,
@@ -16,7 +15,7 @@ import { type IProps } from "../editor.js";
 import type { PHIDOption } from "@powerhousedao/document-engineering/ui";
 
 interface SetFormProps extends Pick<IProps, "document" | "dispatch"> {
-  mode: EditorMode;
+  mode: ViewMode;
   isSplitMode?: boolean;
 }
 

--- a/editors/atlas-set-editor/editor.tsx
+++ b/editors/atlas-set-editor/editor.tsx
@@ -20,7 +20,7 @@ export default function Editor(props: IProps) {
               <SetForm
                 document={props.document}
                 dispatch={props.dispatch}
-                mode={isEditMode ? "Edition" : "DiffRemoved"}
+                mode={isEditMode ? "edition" : "removal"}
                 isSplitMode={isSplitMode}
               />
             }
@@ -28,7 +28,7 @@ export default function Editor(props: IProps) {
               <SetForm
                 document={props.document}
                 dispatch={props.dispatch}
-                mode={isEditMode ? "DiffMixed" : "DiffAdditions"}
+                mode={isEditMode ? "mixed" : "addition"}
                 isSplitMode={isSplitMode}
               />
             }
@@ -37,7 +37,7 @@ export default function Editor(props: IProps) {
           <SetForm
             document={props.document}
             dispatch={props.dispatch}
-            mode={isEditMode ? "Edition" : "DiffMixed"}
+            mode={isEditMode ? "edition" : "mixed"}
           />
         )
       }

--- a/editors/shared/components/diff-fields/enum-diff-field.tsx
+++ b/editors/shared/components/diff-fields/enum-diff-field.tsx
@@ -18,8 +18,8 @@ const EnumDiffField = ({
 }: EnumDiffFieldProps) => {
   const { getValues } = useFormContext();
 
-  if (mode === "Edition" || mode === "Readonly") {
-    return <EnumField disabled={mode === "Readonly"} {...enumProps} />;
+  if (mode === "edition") {
+    return <EnumField {...enumProps} />;
   }
 
   const value = getValues(enumProps.name!) as string;

--- a/editors/shared/components/diff-fields/string-diff-field.tsx
+++ b/editors/shared/components/diff-fields/string-diff-field.tsx
@@ -20,8 +20,8 @@ const StringDiffField = ({
 }: StringDiffFieldProps) => {
   const { getValues } = useFormContext();
 
-  if (mode === "Edition" || mode === "Readonly") {
-    return <StringField disabled={mode === "Readonly"} {...stringProps} />;
+  if (mode === "edition") {
+    return <StringField {...stringProps} />;
   }
 
   const value = (getValues(stringProps.name!) as string) || "";

--- a/editors/shared/components/diff-fields/url-diff-field.tsx
+++ b/editors/shared/components/diff-fields/url-diff-field.tsx
@@ -19,8 +19,8 @@ const UrlDiffField = ({
   const { getValues, watch } = useFormContext();
   const value = watch(urlProps.name!) as string;
 
-  if (mode === "Edition" || mode === "Readonly") {
-    return <UrlField disabled={mode === "Readonly"} {...urlProps} />;
+  if (mode === "edition") {
+    return <UrlField {...urlProps} />;
   }
 
   return (

--- a/editors/shared/components/diff-text.tsx
+++ b/editors/shared/components/diff-text.tsx
@@ -1,12 +1,11 @@
 import { useMemo } from "react";
 import { diffSentences, diffWords } from "diff";
-import type { EditorMode } from "../types.js";
-import { cn } from "@powerhousedao/document-engineering/scalars";
+import { cn, type ViewMode } from "@powerhousedao/document-engineering/scalars";
 
 interface DiffTextProps {
   baseline: string;
   value: string;
-  mode: EditorMode;
+  mode: ViewMode;
   diffMode: "words" | "sentences";
   className?: string;
 }
@@ -28,7 +27,7 @@ export const DiffText = ({
     <span className={cn("leading-[18px]", className)}>
       {wordsDiff.map((word, index) => {
         return word.added ? (
-          mode === "DiffAdditions" || mode === "DiffMixed" ? (
+          mode === "addition" || mode === "mixed" ? (
             <span
               className="bg-green-600/30 mr-1 text-gray-700"
               key={`${word.value}-${index}`}
@@ -37,7 +36,7 @@ export const DiffText = ({
             </span>
           ) : null
         ) : word.removed ? (
-          mode === "DiffRemoved" || mode === "DiffMixed" ? (
+          mode === "removal" || mode === "mixed" ? (
             <span
               className="bg-red-600/30 text-gray-700 mr-1"
               key={`${word.value}-${index}`}

--- a/editors/shared/components/forms/MultiPhIdForm.tsx
+++ b/editors/shared/components/forms/MultiPhIdForm.tsx
@@ -4,7 +4,6 @@ import { useFormMode } from "../../providers/FormModeProvider.js";
 import {
   fetchPHIDOptions,
   fetchSelectedPHIDOption,
-  getViewMode,
 } from "../../utils/utils.js";
 import type { PHIDOption } from "@powerhousedao/document-engineering/ui";
 import {
@@ -32,8 +31,7 @@ const MultiPhIdForm = ({
   onRemove,
   onUpdate,
 }: MultiPhIdFormProps) => {
-  const formMode = useFormMode();
-  const viewMode = getViewMode(formMode);
+  const viewMode = useFormMode();
   // boolean flag to trigger callback recreation only when needed
   const [renderComponentTrigger, setRenderComponentTrigger] = useState(false);
 

--- a/editors/shared/components/forms/generics/GenericPHIDForm.tsx
+++ b/editors/shared/components/forms/generics/GenericPHIDForm.tsx
@@ -3,7 +3,6 @@ import { useFormMode } from "../../../providers/FormModeProvider.js";
 import {
   fetchPHIDOptions,
   fetchSelectedPHIDOption,
-  getViewMode,
 } from "../../../utils/utils.js";
 import type { PHIDOption } from "@powerhousedao/document-engineering/ui";
 import type React from "react";
@@ -38,8 +37,7 @@ const GenericPHIDForm = ({
   required = false,
   initialOptions,
 }: GenericPHIDFormProps) => {
-  const formMode = useFormMode();
-  const viewMode = getViewMode(formMode);
+  const viewMode = useFormMode();
 
   const onSubmit = (data: { phidValue: string }) => {
     if (data.phidValue !== undefined && data.phidValue !== value) {

--- a/editors/shared/components/forms/generics/GenericTextForm.tsx
+++ b/editors/shared/components/forms/generics/GenericTextForm.tsx
@@ -1,7 +1,5 @@
 import { Form, StringField } from "@powerhousedao/document-engineering/scalars";
 import { useFormMode } from "../../../providers/FormModeProvider.js";
-import { StringDiffField } from "../../diff-fields/string-diff-field.js";
-import { getViewMode } from "../../../utils/utils.js";
 import { useEffect, useRef } from "react";
 import type { UseFormReturn, FieldValues } from "react-hook-form";
 
@@ -26,8 +24,7 @@ const GenericTextForm = ({
   multiline = false,
   autoExpand = false,
 }: GenericTextFormProps) => {
-  const formMode = useFormMode();
-  const viewMode = getViewMode(formMode);
+  const mode = useFormMode();
   const formRef = useRef<UseFormReturn<FieldValues>>(null);
 
   // Reset the form when the value changes to keep the form in sync with the value for split mode
@@ -57,7 +54,7 @@ const GenericTextForm = ({
           placeholder={placeholder}
           required={required}
           onBlur={triggerSubmit}
-          viewMode={viewMode}
+          viewMode={mode}
           baseValue={baselineValue}
           multiline={multiline}
           autoExpand={autoExpand}

--- a/editors/shared/providers/FormModeProvider.tsx
+++ b/editors/shared/providers/FormModeProvider.tsx
@@ -1,17 +1,17 @@
 import type React from "react";
 import { createContext, useContext } from "react";
-import type { EditorMode } from "../types.js";
+import { type ViewMode } from "@powerhousedao/document-engineering/scalars";
 
 interface FormModeContextType {
-  mode: EditorMode;
+  mode: ViewMode;
 }
 const FormModeContext = createContext<FormModeContextType>({
-  mode: "Readonly",
+  mode: "edition",
 });
 
 interface FormModeProviderProps {
   children: React.ReactNode;
-  mode: EditorMode;
+  mode: ViewMode;
 }
 
 /**

--- a/editors/shared/types.ts
+++ b/editors/shared/types.ts
@@ -1,3 +1,5 @@
+import { type ViewMode } from "@powerhousedao/document-engineering/scalars";
+
 export type EditorMode =
   | "Edition"
   | "Readonly"
@@ -8,7 +10,7 @@ export type EditorMode =
 export type DiffMode = "words" | "sentences";
 
 export interface BaseDiffFieldProps {
-  mode: EditorMode;
+  mode: ViewMode;
   baselineValue?: string;
   diffMode?: DiffMode;
 }

--- a/editors/shared/utils/utils.ts
+++ b/editors/shared/utils/utils.ts
@@ -2,6 +2,7 @@ import type { PHIDOption } from "@powerhousedao/document-engineering/ui";
 import docsIndex from "../../../scripts/apply-changes/data/index.json" with { type: "json" };
 import { type EditorMode } from "../types.js";
 import type { DocumentDriveDocument } from "document-drive";
+import { type ViewMode } from "@powerhousedao/document-engineering/scalars";
 
 /**
  * @deprecated Use fetchPHIDOptions & fetchSelectedPHIDOption instead
@@ -60,18 +61,14 @@ export const fetchSelectedPHIDOption = (
   return (docsIndex as PHIDOption[]).find((option) => option.value === value);
 };
 
-export const getCardVariant = (mode: EditorMode) => {
-  return mode === "Edition"
-    ? "blue"
-    : mode === "Readonly" || mode === "DiffRemoved"
-      ? "gray"
-      : "green";
+export const getCardVariant = (mode: ViewMode) => {
+  return mode === "edition" ? "blue" : mode === "removal" ? "gray" : "green";
 };
 
-export const getTagText = (mode: string) => {
-  return mode === "Edition"
+export const getTagText = (mode: ViewMode) => {
+  return mode === "edition"
     ? "Edition Atlas"
-    : mode === "Readonly" || mode === "DiffRemoved"
+    : mode === "removal"
       ? "Official Atlas"
       : "Atlas Draft";
 };
@@ -111,17 +108,4 @@ export const parseTitleText = (title: string) => {
     return { docNo: parts[0], name: parts[1] };
   }
   return { docNo: "", name: title };
-};
-
-export const getViewMode = (mode: EditorMode) => {
-  switch (mode) {
-    case "Edition":
-      return "edition";
-    case "DiffRemoved":
-      return "removal";
-    case "DiffAdditions":
-      return "addition";
-    case "DiffMixed":
-      return "mixed";
-  }
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/wAmbLyTg/1004-add-the-boolean-read-only-diff-status-to-the-document-types

## Description
Should add the read only diff status in the Split/Edit
