### PR TITLE
fix(scalars): fix the re-render phidField

### DIFF
--- a/editors/shared/components/forms/MultiPhIdForm.tsx
+++ b/editors/shared/components/forms/MultiPhIdForm.tsx
@@ -33,12 +33,11 @@ const MultiPhIdForm = ({
   baselineValue,
 }: MultiPhIdFormProps) => {
   const viewMode = useFormMode();
-  // Create refs to store latest values
+
   const dataRef = useRef(data);
   const baselineValueRef = useRef(baselineValue);
   const viewModeRef = useRef(viewMode);
 
-  // Update refs when values change
   useEffect(() => {
     dataRef.current = data;
     baselineValueRef.current = baselineValue;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,8 @@ export default tseslint.config(
       "@typescript-eslint/no-empty-object-type": "off",
       "@typescript-eslint/no-duplicate-type-constituents": "off",
       "@typescript-eslint/no-unused-vars": "off",
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
     },
   },
   {


### PR DESCRIPTION
## Ticket
https://trello.com/c/F9R8s73V/990-fix-the-flickering-in-the-phid-when-is-an-array?filter=label:Sprint%2005.06.25%20-%2011.06.25,label:Sprint%2029.05.25%20-%2004.06.25

## Description
- Should ensure that the PHID works properly after inserting a value that match an initial option. After the insert a new value in the PHIDField, the component made a flick in the new item and also in the other components in the arrays of PHIDField
