### PR TITLE
fix: replace labels by a skeleton when loading the base document

### DIFF
--- a/editors/atlas-exploratory-editor/components/AdditionalGuidance.tsx
+++ b/editors/atlas-exploratory-editor/components/AdditionalGuidance.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "../../shared/components/ui/skeleton.js";
+import { FieldSkeleton } from "../../shared/components/field-skeleton.js";
 import { GenericTextForm } from "../../shared/components/forms/generics/GenericTextForm.js";
 
 interface AdditionalGuidanceProps {
@@ -15,7 +15,7 @@ function AdditionalGuidance({
   onSave,
 }: AdditionalGuidanceProps) {
   return loading ? (
-    <Skeleton label="Additional Guidance" className="h-[76px]" />
+    <FieldSkeleton className="h-[76px]" />
   ) : (
     <GenericTextForm
       label="Additional Guidance"

--- a/editors/shared/components/field-skeleton.tsx
+++ b/editors/shared/components/field-skeleton.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "./ui/skeleton.js";
+import { cn } from "@powerhousedao/document-engineering/scalars";
+
+interface FieldSkeletonProps {
+  className?: string;
+}
+
+export const FieldSkeleton = ({ className }: FieldSkeletonProps) => (
+  <div className={cn("w-full flex flex-col gap-2")}>
+    <Skeleton className={cn("max-w-40 h-4 mb-[3px]")} />
+    <Skeleton className={className} />
+  </div>
+);

--- a/editors/shared/components/forms/DocNameForm.tsx
+++ b/editors/shared/components/forms/DocNameForm.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "../ui/skeleton.js";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { GenericTextForm } from "./generics/GenericTextForm.js";
 import type { Maybe } from "document-model";
 
@@ -18,7 +18,7 @@ const DocNameForm = ({
   placeholder = "Name",
 }: DocNameFormProps) => {
   return loading ? (
-    <Skeleton label="Name" />
+    <FieldSkeleton />
   ) : (
     <GenericTextForm
       label="Name"

--- a/editors/shared/components/forms/DocNoForm.tsx
+++ b/editors/shared/components/forms/DocNoForm.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "../ui/skeleton.js";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { GenericTextForm } from "./generics/GenericTextForm.js";
 import type { Maybe } from "document-model";
 
@@ -16,7 +16,7 @@ const DocNoForm = ({
   onSave,
 }: DocNoFormProps) => {
   return loading ? (
-    <Skeleton label="Doc №" />
+    <FieldSkeleton />
   ) : (
     <GenericTextForm
       label="Doc №"

--- a/editors/shared/components/forms/DocTypeForm.tsx
+++ b/editors/shared/components/forms/DocTypeForm.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "../ui/skeleton.js";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { GenericEnumForm } from "./generics/GenericEnumForm.js";
 import type { Maybe } from "document-model";
 import { type FAtlasType } from "../../../../document-models/atlas-foundation/index.js";
@@ -36,7 +36,7 @@ const DocTypeForm = ({
   options = foundationOptions,
 }: DocTypeFormProps) => {
   return loading ? (
-    <Skeleton label="Doc Type *" />
+    <FieldSkeleton />
   ) : (
     <GenericEnumForm
       label={label}

--- a/editors/shared/components/forms/GlobalTagsForm.tsx
+++ b/editors/shared/components/forms/GlobalTagsForm.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "../ui/skeleton.js";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { type SelectOption } from "@powerhousedao/document-engineering/ui";
 import { GenericEnumForm } from "./generics/GenericEnumForm.js";
 import type { Maybe } from "document-model";
@@ -35,7 +35,7 @@ const GlobalTagsForm = ({
   }, []);
 
   return loading ? (
-    <Skeleton label="Tags" />
+    <FieldSkeleton />
   ) : (
     <GenericEnumForm
       label="Tags"

--- a/editors/shared/components/forms/MarkdownContentForm.tsx
+++ b/editors/shared/components/forms/MarkdownContentForm.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "../ui/skeleton.js";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { useEffect, useState } from "react";
 import { MarkdownEditor } from "../markdown-editor.js";
 import { useFormMode } from "../../providers/FormModeProvider.js";
@@ -55,7 +55,7 @@ const MarkdownContentForm: React.FC<MarkdownContentFormProps> = ({
   }
 
   return loading ? (
-    <Skeleton label="Content" className="h-[350px]" />
+    <FieldSkeleton className="h-[350px]" />
   ) : (
     <div className="flex flex-col gap-2">
       <FormLabel disabled={true}>Content</FormLabel>

--- a/editors/shared/components/forms/MasterStatusForm.tsx
+++ b/editors/shared/components/forms/MasterStatusForm.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "../ui/skeleton.js";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { GenericEnumForm } from "./generics/GenericEnumForm.js";
 import type { Maybe } from "document-model";
 import { type FStatus } from "../../../../document-models/atlas-foundation/index.js";
@@ -17,7 +17,7 @@ const MasterStatusForm = ({
   onSave,
 }: MasterStatusFormProps) => {
   return loading ? (
-    <Skeleton label="Status *" />
+    <FieldSkeleton />
   ) : (
     <GenericEnumForm
       label="Status"

--- a/editors/shared/components/forms/MultiPhIdForm.tsx
+++ b/editors/shared/components/forms/MultiPhIdForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback, useMemo, useState } from "react";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { Skeleton } from "../ui/skeleton.js";
 import { ArrayField, type ArrayFieldProps } from "../ArrayField.js";
 import { useFormMode } from "../../providers/FormModeProvider.js";
@@ -59,7 +60,7 @@ const MultiPhIdForm = ({
       // the new item not have initialOptions
       if (props.name === "item-new") {
         return loading ? (
-          <Skeleton label={label} className="h-[92px]" />
+          <FieldSkeleton className="h-[92px]" />
         ) : (
           <PHIDField {...props} />
         );
@@ -77,10 +78,11 @@ const MultiPhIdForm = ({
         data.length > 0 && data[0].id === props.name?.replace("item-", "");
 
       return loading ? (
-        <Skeleton
-          label={isFirstField ? label : undefined}
-          className="h-[92px]"
-        />
+        isFirstField ? (
+          <FieldSkeleton className="h-[92px]" />
+        ) : (
+          <Skeleton className="h-[92px]" />
+        )
       ) : (
         <PHIDField
           {...props}

--- a/editors/shared/components/forms/MultiUrlForm.tsx
+++ b/editors/shared/components/forms/MultiUrlForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback, useMemo, useState } from "react";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { Skeleton } from "../ui/skeleton.js";
 import { ArrayField, type ArrayFieldProps } from "../ArrayField.js";
 import {
@@ -72,7 +73,11 @@ const MultiUrlForm = ({
           data[0].id === props.name?.replace("item-", ""));
 
       return loading ? (
-        <Skeleton label={isFirstField ? label : undefined} />
+        isFirstField ? (
+          <FieldSkeleton />
+        ) : (
+          <Skeleton />
+        )
       ) : (
         <UrlField
           {...props}

--- a/editors/shared/components/forms/SinglePhIdForm.tsx
+++ b/editors/shared/components/forms/SinglePhIdForm.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "../ui/skeleton.js";
+import { FieldSkeleton } from "../field-skeleton.js";
 import { GenericPHIDForm } from "./generics/GenericPHIDForm.js";
 import type { Maybe } from "document-model";
 import type { PHIDOption } from "@powerhousedao/document-engineering/ui";
@@ -34,7 +34,7 @@ const SinglePhIdForm = ({
   fetchOptionsCallback,
 }: SinglePhIdFormProps) => {
   return loading ? (
-    <Skeleton label={label} className="h-[92px]" />
+    <FieldSkeleton className="h-[92px]" />
   ) : (
     <GenericPHIDForm
       label={label}

--- a/editors/shared/components/ui/skeleton.tsx
+++ b/editors/shared/components/ui/skeleton.tsx
@@ -3,25 +3,13 @@ import { cn } from "@powerhousedao/document-engineering/scalars";
 
 const Skeleton = React.forwardRef<
   HTMLDivElement,
-  React.ComponentPropsWithoutRef<"div"> & {
-    label?: string;
-  }
->(({ className, label, ...props }, ref) => (
-  <div className="w-full flex flex-col gap-2">
-    {label && (
-      <label className="mb-[3px] text-sm font-medium leading-4 text-gray-700 cursor-not-allowed">
-        {label}
-      </label>
-    )}
-    <div
-      ref={ref}
-      className={cn(
-        "w-full h-9 animate-pulse rounded-md bg-gray-200",
-        className,
-      )}
-      {...props}
-    />
-  </div>
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("w-full h-9 animate-pulse rounded-md bg-gray-200", className)}
+    {...props}
+  />
 ));
 
 Skeleton.displayName = "Skeleton";


### PR DESCRIPTION
## Ticket
https://trello.com/c/MPhuo91G/1080-keep-the-toggle-selection-after-changing-the-document-in-the-sidebar

## Description
- Replace labels by a skeleton when loading the base document to show the differences

![1](https://github.com/user-attachments/assets/35f644b6-92ac-4056-92ca-72df70fe1aab)
![2](https://github.com/user-attachments/assets/dcc24bf1-d70a-4fad-bd8a-90e57cd72fc0)
![3](https://github.com/user-attachments/assets/dc711df6-ca4c-497a-b755-aefec369c3b2)