### PR TITLE
fix: correctly display "Original Context Data" field differences

### DIFF
--- a/editors/shared/components/forms/MultiUrlForm.tsx
+++ b/editors/shared/components/forms/MultiUrlForm.tsx
@@ -57,12 +57,11 @@ const MultiUrlForm = ({
 
       if (props.name !== "item-new") {
         const fieldId = props.name?.replace("item-", "");
-        const element = data.find((d) => d.id === fieldId);
 
-        if (element !== undefined) {
-          baseValue = baselineValue.find(
-            (baseUrl) => baseUrl === element.value,
-          );
+        const elementIndex = data.findIndex((d) => d.id === fieldId);
+
+        if (elementIndex >= 0 && elementIndex < baselineValue.length) {
+          baseValue = baselineValue[elementIndex];
         }
       }
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/OhvxSD0d/1088-origin-modified-data-does-not-appear-in-the-diff-comparison-pane

## Description
- Correctly display "Original Context Data" field differences

<img width="1920" height="1020" alt="diffs" src="https://github.com/user-attachments/assets/47cd9e36-8d7d-4b14-8bb1-b0b0432d6c79" />