### PR TITLE
Fix/fix index mismatch index in the url

### DIFF
--- a/document-models/atlas-foundation/src/reducers/context.ts
+++ b/document-models/atlas-foundation/src/reducers/context.ts
@@ -6,9 +6,9 @@ export const reducer: AtlasFoundationContextOperations = {
   },
 
   removeContextDataOperation(state, action) {
-    state.originalContextData = state.originalContextData.filter(
-      (contextData) => contextData !== action.input.id,
-    );
+    // Mark the value as deleted to filter it out in the form
+    const index = state.originalContextData.indexOf(action.input.id);
+    state.originalContextData[index] = "";
   },
 
   replaceContextDataOperation(state, action) {

--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -245,9 +245,9 @@ export function ExploratoryForm({
                 baseDocument?.state.global.originalContextData ?? []
               }
               label="Original Context Data"
-              data={documentState.originalContextData.map((element) => {
+              data={documentState.originalContextData.map((element, index) => {
                 return {
-                  id: transformUrl(element),
+                  id: `${transformUrl(element)}-${index}`,
                   value: element,
                 };
               })}

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -183,9 +183,9 @@ export function FoundationForm({
                 baseDocument?.state.global.originalContextData ?? []
               }
               label="Original Context Data"
-              data={documentState.originalContextData.map((element) => {
+              data={documentState.originalContextData.map((element, index) => {
                 return {
-                  id: transformUrl(element),
+                  id: `${transformUrl(element)}-${index}`,
                   value: element,
                 };
               })}

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -196,9 +196,9 @@ export function GroundingForm({
                 baseDocument?.state.global.originalContextData ?? []
               }
               label="Original Context Data"
-              data={documentState.originalContextData.map((element) => {
+              data={documentState.originalContextData.map((element, index) => {
                 return {
-                  id: transformUrl(element),
+                  id: `${transformUrl(element)}-${index}`,
                   value: element,
                 };
               })}

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -44,10 +44,9 @@ export function MultiParentForm({
   const cardVariant = getCardVariant(mode);
   const tagText = getTagText(mode);
   const documentState = document.state.global;
+  const baseDocument = useBaseDocumentCached(document, context);
 
   const fetchOptionsCallback = useParentOptions("sky/atlas-multiparent");
-
-  const baseDocument = useBaseDocumentCached(document, context);
   const loading = shouldShowSkeleton(mode, baseDocument);
 
   return (
@@ -178,9 +177,9 @@ export function MultiParentForm({
                 baseDocument?.state.global.originalContextData ?? []
               }
               label="Original Context Data"
-              data={documentState.originalContextData.map((element) => {
+              data={documentState.originalContextData.map((element, index) => {
                 return {
-                  id: transformUrl(element),
+                  id: `${transformUrl(element)}-${index}`,
                   value: element,
                 };
               })}

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -104,12 +104,14 @@ export function ScopeForm({
                   baseDocument?.state.global.originalContextData ?? []
                 }
                 label="Original Context Data"
-                data={documentState.originalContextData.map((element) => {
-                  return {
-                    id: transformUrl(element),
-                    value: element,
-                  };
-                })}
+                data={documentState.originalContextData.map(
+                  (element, index) => {
+                    return {
+                      id: `${transformUrl(element)}-${index}`,
+                      value: element,
+                    };
+                  },
+                )}
                 onAdd={(value) => {
                   dispatch(
                     actions.addContextData({

--- a/editors/shared/components/forms/MultiUrlForm.tsx
+++ b/editors/shared/components/forms/MultiUrlForm.tsx
@@ -105,10 +105,13 @@ const MultiUrlForm = ({
       onAdd={onAdd}
       onRemove={onRemove}
       onUpdate={onUpdate}
-      fields={data.map((element) => ({
-        id: element.id,
-        value: element.value,
-      }))}
+      fields={data
+        // Filter out the deleted values to avoid index mismatch
+        .filter((element) => element.value !== "")
+        .map((element) => ({
+          id: element.id,
+          value: element.value,
+        }))}
       label={label}
       component={renderComponent}
       componentProps={{


### PR DESCRIPTION
## Ticket
- https://trello.com/c/OhvxSD0d/1088-origin-modified-data-does-not-appear-in-the-diff-comparison-pane
## Description
- A1.9 - Sky Core Governance Security  document. Original Context Data section. When removing a URL, the diff comparison should be indicated only for the element removed (if applicable). Removing a URL triggers a diff comparison that detects changes in all the URLs.