### PR TITLE
fix(atlas): fix the name of scope documents

### DIFF
--- a/editors/atlas-scope-editor/editor.tsx
+++ b/editors/atlas-scope-editor/editor.tsx
@@ -8,7 +8,7 @@ export type IProps = EditorProps<AtlasScopeDocument>;
 export default function Editor(props: IProps) {
   return (
     <EditorLayout
-      title="Atlas Explorer - The Support Scope"
+      title="Atlas Scope"
       notionId={props.document.state.global.notionId}
       readOnlyModeEnabled={true}
       splitModeEnabled={true}


### PR DESCRIPTION

## Ticket
- https://trello.com/c/VxEAOY5z/1109-change-the-title-of-the-scope-documents-to-atlas-scope
## Description
- Should change the "Atlas Explorer - The Support Scope" doc type to "Atlas Scope" only for the scope documents.