### PR TITLE
fix(scalars): fix missing icon in multiparent type needed_research

### DIFF
--- a/editors/drive-explorer/sidebar-utils.ts
+++ b/editors/drive-explorer/sidebar-utils.ts
@@ -17,7 +17,7 @@ export function buildSidebarTree(allNodes: Record<string, AtlasArticle>) {
         icon: "FolderClose",
         expandedIcon: "FolderOpen",
       };
-    } else if (type === "neededResearch") {
+    } else if (type === "needed_research") {
       icons = {
         icon: "Tube",
       };


### PR DESCRIPTION
## Ticket
https://trello.com/c/tBpocujb/1110-needed-research-icon-is-not-visible-in-the-sidebar-when-the-document-is-created

## Description
- Should ensure that all the icons associated with the document types are displayed properly in the sidebar.
