### PR TITLE
fix(atlas): add docNo in the update operation

### DIFF
--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -166,13 +166,18 @@ export function MultiParentForm({
                   typeof newData?.path === "object"
                     ? newData.path.text
                     : newData?.path;
-
                 dispatch(
                   actions.replaceParent({
                     prevID: prevId,
                     id: newId,
                     title: newData?.title ?? "",
                     documentType: documentType ?? "",
+                    docNo:
+                      newData &&
+                      typeof newData === "object" &&
+                      "docNo" in newData
+                        ? (newData as { docNo?: string }).docNo
+                        : undefined,
                   }),
                 );
               }}


### PR DESCRIPTION
## Ticket
- https://trello.com/c/Fu7AV5Jc/1105-multiparent-document-is-created-with-null-when-no-doc-number-is-provided

## Description 
- Multiparent document, parent document already inserted. Changing the parent document.  **Expected Output:** The multiparent node should be moved to the new parent node and take the proper document number. **Current Output:** The multiparent node is moved to the proper place, but the document number is displayed as Null; it is not taking the parent document number.  Update the DocNumber when update the parent in the docs