### PR TITLE
fix(scalars): fix the issue generic phID add same placeholder all docs

### DIFF
--- a/editors/drive-explorer/sidebar-utils.ts
+++ b/editors/drive-explorer/sidebar-utils.ts
@@ -40,18 +40,11 @@ export function buildSidebarTree(allNodes: Record<string, AtlasArticle>) {
     }
 
     // get the right title for the node depending on the document type
-    const title =
-      "sky/atlas-set" === node.documentType ||
-      "sky/atlas-multiparent" === node.documentType
-        ? node.global.name
-        : `${node.global?.docNo || "Doc No"} - ${node.global.name || "Name"}`;
+    const title = `${node.global?.docNo || "Doc No"} - ${node.global.name || "Name"}`;
 
     const isNewDocs = node.global?.docNo === "" && node.global.name === "";
     // check if the document is a new document with no docNo in the name to add placeholder
-    const isNewDocsWithNoDocNoInTitle =
-      node.documentType !== "sky/atlas-set" &&
-      node.documentType !== "sky/atlas-multiparent" &&
-      isNewDocs;
+    const isNewDocsWithNoDocNoInTitle = isNewDocs;
 
     nodesById[key] = {
       id: key,

--- a/editors/drive-explorer/sidebar-utils.ts
+++ b/editors/drive-explorer/sidebar-utils.ts
@@ -39,9 +39,10 @@ export function buildSidebarTree(allNodes: Record<string, AtlasArticle>) {
       status = "MODIFIED";
     }
 
-    // get the right title for the node depending on the document type
-    const title = `${node.global?.docNo || "Doc No"} - ${node.global.name || "Name"}`;
-
+    let title = `${node.global?.docNo || "Doc No"} - ${node.global.name || "Name"}`;
+    if (node.documentType === "sky/atlas-multiparent") {
+      title = node.global.name || "Name";
+    }
     const isNewDocs = node.global?.docNo === "" && node.global.name === "";
     // check if the document is a new document with no docNo in the name to add placeholder
     const isNewDocsWithNoDocNoInTitle = isNewDocs;
@@ -65,7 +66,9 @@ export function buildSidebarTree(allNodes: Record<string, AtlasArticle>) {
         for (const parent of parents) {
           const nodeWithCorrectTitle = {
             ...nodesById[key],
-            title: `${parent.docNo} - ${value.global.name}`,
+            title: parent.docNo
+              ? `${parent.docNo} - ${value.global.name || "Name"}`
+              : `${value.global.name || "Name"}`,
           };
           nodesById[parent.id]?.children?.push(nodeWithCorrectTitle);
         }

--- a/editors/shared/components/forms/generics/GenericPHIDForm.tsx
+++ b/editors/shared/components/forms/generics/GenericPHIDForm.tsx
@@ -80,7 +80,11 @@ const GenericPHIDForm = ({
           onBlur={triggerSubmit}
           viewMode={viewMode}
           baseValue={baselineValue}
-          basePreviewIcon={baselineIcon as PHIDOption["icon"]}
+          basePreviewIcon={
+            baselineIcon && baselineIcon !== ""
+              ? (baselineIcon as PHIDOption["icon"])
+              : undefined
+          }
           basePreviewTitle={baselineTitle}
           basePreviewPath={baselineType}
           basePreviewDescription={baselineDescription}


### PR DESCRIPTION
## Ticket
- https://trello.com/c/4QykDyTJ/1111-multiparent-document-is-displayed-with-the-name-undefined-in-the-sidebar


## Description
- Should the multi-parent node be created by default with the placeholder: Name. When create a new multi-parent document,  this placeholder should be show

## ScreenShot
<img width="1284" height="1041" alt="prove-2" src="https://github.com/user-attachments/assets/23a8d6da-c40e-45f6-a67b-f5077ca1aac9" />
<img width="1289" height="963" alt="prove" src="https://github.com/user-attachments/assets/dad54478-3714-475b-ba67-cd10df80c8db" />
