### PR TITLE
fix(altas): remove the placeholder in diff mode

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -80,7 +80,7 @@ export function ExploratoryForm({
   const showLastElement = shouldShowLastElement({
     mode,
     isSplitMode,
-    contextDataLength: documentState.originalContextData.length,
+    contextDataLength: documentState?.originalContextData?.length ?? 0,
   });
 
   return (

--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -4,6 +4,7 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
+  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";
@@ -73,6 +74,14 @@ export function ExploratoryForm({
 
   const baseDocument = useBaseDocumentCached(document, context);
   const loading = shouldShowSkeleton(mode, baseDocument);
+
+  const preserveSpace = mode === "mixed" && isSplitMode;
+
+  const showLastElement = shouldShowLastElement({
+    mode,
+    isSplitMode,
+    contextDataLength: documentState.originalContextData.length,
+  });
 
   return (
     <FormModeProvider mode={mode}>
@@ -238,9 +247,14 @@ export function ExploratoryForm({
               getWidthClassName(!!isSplitMode),
             )}
           >
+            {preserveSpace &&
+              documentState.originalContextData.length === 0 && (
+                <div className={cn("h-[63px]")} />
+              )}
             <MultiUrlForm
               loading={loading}
               viewMode={mode}
+              showAddField={showLastElement}
               baselineValue={
                 baseDocument?.state.global.originalContextData ?? []
               }
@@ -273,6 +287,9 @@ export function ExploratoryForm({
                 );
               }}
             />
+            {preserveSpace && documentState.originalContextData.length > 0 && (
+              <div className={cn("h-[36px]")} />
+            )}
 
             <GlobalTagsForm
               loading={loading}

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -72,7 +72,7 @@ export function FoundationForm({
   const showLastElement = shouldShowLastElement({
     mode,
     isSplitMode,
-    contextDataLength: documentState.originalContextData.length,
+    contextDataLength: documentState?.originalContextData?.length ?? 0,
   });
 
   return (

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -4,6 +4,7 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
+  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";
@@ -65,6 +66,14 @@ export function FoundationForm({
 
   const baseDocument = useBaseDocumentCached(document, context);
   const loading = shouldShowSkeleton(mode, baseDocument);
+
+  const preserveSpace = mode === "mixed" && isSplitMode;
+
+  const showLastElement = shouldShowLastElement({
+    mode,
+    isSplitMode,
+    contextDataLength: documentState.originalContextData.length,
+  });
 
   return (
     <FormModeProvider mode={mode}>
@@ -175,10 +184,14 @@ export function FoundationForm({
               }}
               initialOptions={[parentPHIDInitialOption]}
             />
-
+            {preserveSpace &&
+              documentState.originalContextData.length === 0 && (
+                <div className={cn("h-[63px]")} />
+              )}
             <MultiUrlForm
               loading={loading}
               viewMode={mode}
+              showAddField={showLastElement}
               baselineValue={
                 baseDocument?.state.global.originalContextData ?? []
               }
@@ -211,7 +224,9 @@ export function FoundationForm({
                 );
               }}
             />
-
+            {preserveSpace && documentState.originalContextData.length > 0 && (
+              <div className={cn("h-[36px]")} />
+            )}
             <GlobalTagsForm
               loading={loading}
               value={documentState.globalTags}

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -4,6 +4,7 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
+  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";
@@ -68,6 +69,13 @@ export function GroundingForm({
 
   const baseDocument = useBaseDocumentCached(document, context);
   const loading = shouldShowSkeleton(mode, baseDocument);
+
+  const preserveSpace = mode === "mixed" && isSplitMode;
+  const showLastElement = shouldShowLastElement({
+    mode,
+    isSplitMode,
+    contextDataLength: documentState.originalContextData.length,
+  });
 
   return (
     <FormModeProvider mode={mode}>
@@ -188,9 +196,13 @@ export function GroundingForm({
               }}
               initialOptions={[parentPHIDInitialOption]}
             />
-
+            {preserveSpace &&
+              documentState.originalContextData.length === 0 && (
+                <div className={cn("h-[63px]")} />
+              )}
             <MultiUrlForm
               loading={loading}
+              showAddField={showLastElement}
               viewMode={mode}
               baselineValue={
                 baseDocument?.state.global.originalContextData ?? []
@@ -225,6 +237,9 @@ export function GroundingForm({
               }}
             />
 
+            {preserveSpace && documentState.originalContextData.length > 0 && (
+              <div className={cn("h-[36px]")} />
+            )}
             <GlobalTagsForm
               loading={loading}
               value={documentState.globalTags}

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -74,7 +74,7 @@ export function GroundingForm({
   const showLastElement = shouldShowLastElement({
     mode,
     isSplitMode,
-    contextDataLength: documentState.originalContextData.length,
+    contextDataLength: documentState?.originalContextData?.length ?? 0,
   });
 
   return (

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -4,6 +4,7 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
+  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
@@ -49,6 +50,13 @@ export function MultiParentForm({
 
   const baseDocument = useBaseDocumentCached(document, context);
   const loading = shouldShowSkeleton(mode, baseDocument);
+
+  const preserveSpace = mode === "mixed" && isSplitMode;
+  const showLastElement = shouldShowLastElement({
+    mode,
+    isSplitMode,
+    contextDataLength: documentState.originalContextData.length,
+  });
 
   return (
     <FormModeProvider mode={mode}>
@@ -182,10 +190,15 @@ export function MultiParentForm({
                 );
               }}
             />
+            {preserveSpace &&
+              documentState.originalContextData.length === 0 && (
+                <div className={cn("h-[63px]")} />
+              )}
 
             <MultiUrlForm
               loading={loading}
               viewMode={mode}
+              showAddField={showLastElement}
               baselineValue={
                 baseDocument?.state.global.originalContextData ?? []
               }
@@ -218,7 +231,9 @@ export function MultiParentForm({
                 );
               }}
             />
-
+            {preserveSpace && documentState.originalContextData.length > 0 && (
+              <div className={cn("h-[36px]")} />
+            )}
             <GlobalTagsForm
               loading={loading}
               value={documentState.globalTags}

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -55,7 +55,7 @@ export function MultiParentForm({
   const showLastElement = shouldShowLastElement({
     mode,
     isSplitMode,
-    contextDataLength: documentState.originalContextData.length,
+    contextDataLength: documentState?.originalContextData?.length ?? 0,
   });
 
   return (

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -4,6 +4,7 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
+  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import {
@@ -42,6 +43,13 @@ export function ScopeForm({
 
   const baseDocument = useBaseDocumentCached(document, context);
   const loading = shouldShowSkeleton(mode, baseDocument);
+
+  const preserveSpace = mode === "mixed" && isSplitMode;
+  const showLastElement = shouldShowLastElement({
+    mode,
+    isSplitMode,
+    contextDataLength: documentState.originalContextData.length,
+  });
 
   return (
     <FormModeProvider mode={mode}>
@@ -97,9 +105,14 @@ export function ScopeForm({
 
           <div className={cn("flex flex-col gap-4")}>
             <div className={cn(getWidthClassName(isSplitMode ?? false))}>
+              {preserveSpace &&
+                documentState.originalContextData.length === 0 && (
+                  <div className={cn("h-[63px]")} />
+                )}
               <MultiUrlForm
                 loading={loading}
                 viewMode={mode}
+                showAddField={showLastElement}
                 baselineValue={
                   baseDocument?.state.global.originalContextData ?? []
                 }
@@ -133,6 +146,9 @@ export function ScopeForm({
                 }}
               />
             </div>
+            {preserveSpace && documentState.originalContextData.length > 0 && (
+              <div className={cn("h-[36px]")} />
+            )}
             <div className={cn(getWidthClassName(isSplitMode ?? false))}>
               <GlobalTagsForm
                 loading={loading}

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -48,7 +48,7 @@ export function ScopeForm({
   const showLastElement = shouldShowLastElement({
     mode,
     isSplitMode,
-    contextDataLength: documentState.originalContextData.length,
+    contextDataLength: documentState?.originalContextData?.length ?? 0,
   });
 
   return (

--- a/editors/shared/components/ArrayField.tsx
+++ b/editors/shared/components/ArrayField.tsx
@@ -29,7 +29,7 @@ export interface ArrayFieldProps<TValue, TProps> {
   label: string;
   component: (props: TProps) => React.ReactNode;
   componentProps: TProps;
-  showAddField?: boolean; // Controlar si mostrar el campo de agregar nuevos elementos
+  showAddField?: boolean;
 }
 
 const ArrayField = <TValue, TProps>({
@@ -126,8 +126,6 @@ const ArrayField = <TValue, TProps>({
               required={false}
             />
           ))}
-
-          {/* Add field - solo mostrar si showAddField es true */}
           {showAddField && (
             <Component
               {...componentProps}

--- a/editors/shared/components/ArrayField.tsx
+++ b/editors/shared/components/ArrayField.tsx
@@ -29,6 +29,7 @@ export interface ArrayFieldProps<TValue, TProps> {
   label: string;
   component: (props: TProps) => React.ReactNode;
   componentProps: TProps;
+  showAddField?: boolean; // Controlar si mostrar el campo de agregar nuevos elementos
 }
 
 const ArrayField = <TValue, TProps>({
@@ -39,6 +40,7 @@ const ArrayField = <TValue, TProps>({
   label,
   component: Component,
   componentProps,
+  showAddField = true,
 }: ArrayFieldProps<TValue, TProps>) => {
   const formRef = useRef<UseFormReturn<FieldValues>>(null);
 
@@ -72,7 +74,7 @@ const ArrayField = <TValue, TProps>({
         break;
       }
     }
-    if (data["item-new"]) {
+    if (data["item-new"] && showAddField) {
       // create a new field/item
       onAdd(data["item-new"]);
       formRef.current?.reset({ "item-new": "" }); // reset to empty to allow adding another items
@@ -81,15 +83,17 @@ const ArrayField = <TValue, TProps>({
 
   // create a default values object with the values and the new item
   const defaultValues = useMemo(() => {
+    const fieldValues = fields
+      .map((field) => ({
+        [`item-${field.id}`]: field.value,
+      }))
+      .reduce((acc, curr) => ({ ...acc, ...curr }), {});
+
     return {
-      ...fields
-        .map((field) => ({
-          [`item-${field.id}`]: field.value,
-        }))
-        .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
-      [`item-new`]: "",
+      ...fieldValues,
+      ...(showAddField ? { [`item-new`]: "" } : {}),
     };
-  }, [fields]);
+  }, [fields, showAddField]);
 
   // update the form in case the field name changes due to the number of items
   // also keep in sync the values with the state of the form
@@ -123,14 +127,16 @@ const ArrayField = <TValue, TProps>({
             />
           ))}
 
-          {/* Add field */}
-          <Component
-            {...componentProps}
-            label={fields.length === 0 ? label : undefined}
-            name="item-new"
-            onBlur={triggerSubmit}
-            required={false}
-          />
+          {/* Add field - solo mostrar si showAddField es true */}
+          {showAddField && (
+            <Component
+              {...componentProps}
+              label={fields.length === 0 ? label : undefined}
+              name="item-new"
+              onBlur={triggerSubmit}
+              required={false}
+            />
+          )}
         </div>
       )}
     </Form>

--- a/editors/shared/components/forms/MultiUrlForm.tsx
+++ b/editors/shared/components/forms/MultiUrlForm.tsx
@@ -16,12 +16,13 @@ type CommonDataProps = {
 interface MultiUrlFormProps
   extends Omit<
     ArrayFieldProps<string, UrlFieldProps>,
-    "fields" | "componentProps" | "component"
+    "fields" | "componentProps" | "component" | "showAddField"
   > {
   loading?: boolean;
   data: CommonDataProps[];
   viewMode: ViewMode;
   baselineValue: string[];
+  showAddField?: boolean;
 }
 
 const MultiUrlForm = ({
@@ -33,6 +34,7 @@ const MultiUrlForm = ({
   onUpdate,
   viewMode,
   baselineValue,
+  showAddField,
 }: MultiUrlFormProps) => {
   // boolean flag to trigger callback recreation only when needed
   const [renderComponentTrigger, setRenderComponentTrigger] = useState(false);
@@ -105,6 +107,7 @@ const MultiUrlForm = ({
       onAdd={onAdd}
       onRemove={onRemove}
       onUpdate={onUpdate}
+      showAddField={showAddField}
       fields={data.map((element) => ({
         id: element.id,
         value: element.value,

--- a/editors/shared/components/forms/MultiUrlForm.tsx
+++ b/editors/shared/components/forms/MultiUrlForm.tsx
@@ -16,13 +16,12 @@ type CommonDataProps = {
 interface MultiUrlFormProps
   extends Omit<
     ArrayFieldProps<string, UrlFieldProps>,
-    "fields" | "componentProps" | "component" | "showAddField"
+    "fields" | "componentProps" | "component"
   > {
   loading?: boolean;
   data: CommonDataProps[];
   viewMode: ViewMode;
   baselineValue: string[];
-  showAddField?: boolean;
 }
 
 const MultiUrlForm = ({

--- a/editors/shared/utils/utils.ts
+++ b/editors/shared/utils/utils.ts
@@ -91,3 +91,26 @@ export const shouldShowSkeleton = (
 ) => {
   return mode !== "edition" && baseDocument === null;
 };
+
+interface ShowLastElementOptions {
+  mode: ViewMode;
+  isSplitMode?: boolean;
+  contextDataLength: number;
+}
+
+export function shouldShowLastElement({
+  mode,
+  isSplitMode = false,
+  contextDataLength,
+}: ShowLastElementOptions): boolean {
+  if (mode === "edition") return true;
+
+  const hasNoContextData = contextDataLength === 0;
+  if (!hasNoContextData) return false;
+
+  if ((mode === "addition" || mode === "removal") && isSplitMode) return true;
+
+  if (mode === "mixed" && !isSplitMode) return true;
+
+  return false;
+}

--- a/editors/shared/utils/utils.ts
+++ b/editors/shared/utils/utils.ts
@@ -103,14 +103,20 @@ export function shouldShowLastElement({
   isSplitMode = false,
   contextDataLength,
 }: ShowLastElementOptions): boolean {
-  if (mode === "edition") return true;
-
   const hasNoContextData = contextDataLength === 0;
-  if (!hasNoContextData) return false;
 
-  if ((mode === "addition" || mode === "removal") && isSplitMode) return true;
+  switch (mode) {
+    case "edition":
+      return true;
 
-  if (mode === "mixed" && !isSplitMode) return true;
+    case "addition":
+    case "removal":
+      return hasNoContextData && isSplitMode;
 
-  return false;
+    case "mixed":
+      return hasNoContextData && !isSplitMode;
+
+    default:
+      return false;
+  }
 }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/gZUTKmRI/1107-placeholder-fields-should-not-be-displayed-in-the-diff-comparison-pane


## Description
- Should remove the placeholder field in the diff comparison pane. Its no necesary add other fields to match in the layout, instead remove and adjust the rest of the fields