### PR TITLE
fix(atlas): remove the ! condition and get fields as source of true

### DIFF
--- a/editors/shared/components/ArrayField.tsx
+++ b/editors/shared/components/ArrayField.tsx
@@ -42,40 +42,32 @@ const ArrayField = <TValue, TProps>({
 }: ArrayFieldProps<TValue, TProps>) => {
   const formRef = useRef<UseFormReturn<FieldValues>>(null);
 
-  const onSubmit = (data: Record<`item-${number}` | "item-new", TValue>) => {
-    for (const [key, value] of Object.entries(data)) {
-      if (key === "item-new") continue;
+  const onSubmit = (data: Record<string, TValue>) => {
+    fields.forEach((field, index) => {
+      const formKey = `item-${field.id}`;
+      if (!(formKey in data)) {
+        return;
+      }
 
-      const id = key.replace("item-", "");
-      const field = fields.find((f) => f.id === id)!;
-      const fieldIndex = fields.indexOf(field);
-      if (value !== field?.value) {
-        if (value === "" || value === null) {
-          // remove the items when the value changes to empty
-          onRemove({
-            value: field.value,
-            id: field.id,
-            index: fieldIndex,
-          }); // remove original value
+      const formValue = data[formKey];
 
-          // unregister the field as it will be removed
-          formRef.current?.unregister(`item-${field.id}`);
+      if (formValue !== field.value) {
+        if (formValue === "" || formValue === null) {
+          onRemove({ value: field.value, id: field.id, index });
+          formRef.current?.unregister(formKey);
         } else {
-          // update the item if the value changed
           onUpdate({
             previousValue: field.value,
-            value,
+            value: formValue,
             id: field.id,
-            index: fieldIndex,
+            index,
           });
         }
-        break;
       }
-    }
+    });
     if (data["item-new"]) {
-      // create a new field/item
       onAdd(data["item-new"]);
-      formRef.current?.reset({ "item-new": "" }); // reset to empty to allow adding another items
+      formRef.current?.resetField("item-new", { defaultValue: "" });
     }
   };
 

--- a/editors/shared/components/toggle-switch.tsx
+++ b/editors/shared/components/toggle-switch.tsx
@@ -14,10 +14,10 @@ export default function ToggleSwitch({
   onChange,
   className,
 }: ToggleProps) {
+  const [selectedIndex, setSelectedIndex] = useState(defaultSelected);
   if (options.length === 0) {
     return null;
   }
-  const [selectedIndex, setSelectedIndex] = useState(defaultSelected);
 
   const handleOptionClick = (index: number) => {
     setSelectedIndex(index);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,7 +55,7 @@ export default tseslint.config(
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/no-empty-object-type": "off",
       "@typescript-eslint/no-duplicate-type-constituents": "off",
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": "warn",
     },
   },
   {
@@ -70,6 +70,10 @@ export default tseslint.config(
     plugins: {
       react: reactPlugin,
       "react-hooks": reactHooksPlugin,
+    },
+    rules: {
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
     },
   }
 );


### PR DESCRIPTION
## Ticket
- https://trello.com/c/0c0YJofT/1113-cannot-read-properties-of-undefined-reading-value-error-appears-after-changing-a-parent-document

## Description
-  Should ensure that the update in the parent documents is applied properly. 
- Ensure that updates to the parent documents are applied correctly.
- On submit, the form is trying to process IDs of fields that have already been deleted.