### PR TITLE
fix(atlas): edition mode don't show last PHID

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
@@ -56,6 +55,14 @@ export function MultiParentForm({
     mode,
     isSplitMode,
     contextDataLength: documentState?.originalContextData?.length ?? 0,
+  });
+  const {
+    preserveSpace: preserveSpaceParents,
+    showLastElement: showLastElementParents,
+  } = useElementVisibility({
+    mode,
+    isSplitMode,
+    contextDataLength: documentState.parents.length ?? 0,
   });
 
   return (
@@ -125,6 +132,7 @@ export function MultiParentForm({
           >
             <MultiPhIdForm
               loading={loading}
+              showAddField={showLastElementParents}
               label="Parent Documents"
               data={documentState.parents.map((element) => {
                 const initialOption: PHIDOption = {
@@ -190,6 +198,9 @@ export function MultiParentForm({
                 );
               }}
             />
+            {preserveSpaceParents && documentState.parents.length !== 0 && (
+              <div className={cn("h-[92px]")} />
+            )}
             {preserveSpace &&
               documentState.originalContextData.length === 0 && (
                 <div className={cn("h-[63px]")} />

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowLastElement,
   shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import {

--- a/editors/shared/components/forms/MultiPhIdForm.tsx
+++ b/editors/shared/components/forms/MultiPhIdForm.tsx
@@ -24,6 +24,7 @@ interface MultiPhIdFormProps
   data: CommonDataProps[];
   fetchOptionsCallback: (value: string) => PHIDOption[];
   baselineValue: MDocumentLink[];
+  showAddField: boolean;
 }
 
 const MultiPhIdForm = ({
@@ -35,6 +36,7 @@ const MultiPhIdForm = ({
   onUpdate,
   fetchOptionsCallback,
   baselineValue,
+  showAddField,
 }: MultiPhIdFormProps) => {
   const viewMode = useFormMode();
   // boolean flag to trigger callback recreation only when needed
@@ -108,6 +110,7 @@ const MultiPhIdForm = ({
       onAdd={onAdd}
       onRemove={onRemove}
       onUpdate={onUpdate}
+      showAddField={showAddField}
       fields={data.map((element) => ({
         id: element.id,
         value: element.id,

--- a/editors/shared/hooks/useElementVisibility.ts
+++ b/editors/shared/hooks/useElementVisibility.ts
@@ -19,7 +19,8 @@ export function useElementVisibility({
   contextDataLength,
 }: UseFormUIProps): UseFormUIResult {
   const result = useMemo(() => {
-    const preserveSpace = mode === "mixed" && !!isSplitMode;
+    const preserveSpace =
+      mode === "mixed" && !!isSplitMode && contextDataLength !== 0;
 
     const showLastElement = shouldShowLastElement({
       mode,

--- a/editors/shared/utils/utils.ts
+++ b/editors/shared/utils/utils.ts
@@ -112,10 +112,8 @@ export function shouldShowLastElement({
     case "addition":
     case "removal":
       return hasNoContextData && isSplitMode;
-
     case "mixed":
-      return hasNoContextData && !isSplitMode;
-
+      return hasNoContextData;
     default:
       return false;
   }


### PR DESCRIPTION
## Ticket
https://trello.com/c/gZUTKmRI/1107-placeholder-fields-should-not-be-displayed-in-the-diff-comparison-pane

## Description
- Should remove the placeholder field in the diff comparison pane. For the PHID component in multi-parent document
