### PR TITLE
fix: exclude the current document from its parent list in PHID-based fields

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -48,7 +48,10 @@ export function ExploratoryForm({
   const cardVariant = getCardVariant(mode);
   const tagText = getTagText(mode);
 
-  const fetchOptionsCallback = useParentOptions("sky/atlas-exploratory");
+  const fetchOptionsCallback = useParentOptions(
+    "sky/atlas-exploratory",
+    document.header.id,
+  );
 
   const originalDocumentState = document.state.global;
   const parentId = originalDocumentState.parent?.id

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -42,7 +42,10 @@ export function FoundationForm({
   const cardVariant = getCardVariant(mode);
   const tagText = getTagText(mode);
 
-  const fetchOptionsCallback = useParentOptions("sky/atlas-foundation");
+  const fetchOptionsCallback = useParentOptions(
+    "sky/atlas-foundation",
+    document.header.id,
+  );
 
   const originalDocumentState = document.state.global;
   const parentId = originalDocumentState.parent?.id

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -45,7 +45,10 @@ export function GroundingForm({
   const cardVariant = getCardVariant(mode);
   const tagText = getTagText(mode);
 
-  const fetchOptionsCallback = useParentOptions("sky/atlas-grounding");
+  const fetchOptionsCallback = useParentOptions(
+    "sky/atlas-grounding",
+    document.header.id,
+  );
 
   const originalDocumentState = document.state.global;
   const parentId = originalDocumentState.parent?.id

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -45,7 +45,10 @@ export function MultiParentForm({
   const tagText = getTagText(mode);
   const documentState = document.state.global;
 
-  const fetchOptionsCallback = useParentOptions("sky/atlas-multiparent");
+  const fetchOptionsCallback = useParentOptions(
+    "sky/atlas-multiparent",
+    document.header.id,
+  );
 
   const baseDocument = useBaseDocumentCached(document, context);
   const loading = shouldShowSkeleton(mode, baseDocument);

--- a/editors/atlas-set-editor/components/SetForm.tsx
+++ b/editors/atlas-set-editor/components/SetForm.tsx
@@ -32,7 +32,10 @@ export function SetForm({
   const cardVariant = getCardVariant(mode);
   const tagText = getTagText(mode);
 
-  const fetchOptionsCallback = useParentOptions("sky/atlas-set");
+  const fetchOptionsCallback = useParentOptions(
+    "sky/atlas-set",
+    document.header.id,
+  );
 
   const parentId = document.state.global.parent?.id
     ? `phd:${document.state.global.parent.id}`

--- a/editors/shared/hooks/useParentOptions.ts
+++ b/editors/shared/hooks/useParentOptions.ts
@@ -72,12 +72,17 @@ const filterFnMap: Record<AllowedDocumentType, FilterFn> = {
 
 export function useParentOptions(
   documentType: AllowedDocumentType,
+  documentId: string,
 ): (value: string) => PHIDOption[] {
   const documentsLink = useDocumentsLink(filterFnMap[documentType]);
   const fetchOptionsCallback = useCallback(
     (value: string) => {
       const lowerCaseValue = value.toLowerCase();
       return documentLinksToPHIDOptions(documentsLink).filter((doc) => {
+        if (doc.value === `phd:${documentId}`) {
+          return false;
+        }
+
         const pathText =
           typeof doc.path === "object" ? doc.path.text : doc.path;
         return (
@@ -87,7 +92,7 @@ export function useParentOptions(
         );
       });
     },
-    [documentsLink],
+    [documentsLink, documentId],
   );
 
   return fetchOptionsCallback;


### PR DESCRIPTION
## Ticket
https://trello.com/c/AWOgrthv/1144-documents-cant-be-their-own-parent

## Description
- Should ensure that in the parent documents list, the own PHID document is not listed