### PR TITLE
fix(atlas): set document should no have number

### DIFF
--- a/editors/drive-explorer/sidebar-utils.ts
+++ b/editors/drive-explorer/sidebar-utils.ts
@@ -46,6 +46,9 @@ export function buildSidebarTree(
     if (node.documentType === "sky/atlas-multiparent") {
       title = node.global.name || "Name";
     }
+    if (node.documentType === "sky/atlas-set") {
+      title = node.global.name || "Name";
+    }
     const isNewDocs = node.global?.docNo === "" && node.global.name === "";
     // check if the document is a new document with no docNo in the name to add placeholder
     const isNewDocsWithNoDocNoInTitle = isNewDocs;


### PR DESCRIPTION
## Ticket
https://trello.com/c/ifPlHVoe/1154-set-document-should-not-be-created-in-the-sidebar-with-doc-no-placeholder

## Description
- Should ensure that the Set document type doesn't show Doc No in the node tree.

## ScreenShoot
<img width="1368" height="897" alt="prueba" src="https://github.com/user-attachments/assets/6a9e0bfe-753b-4f75-9039-3defa278c05a" />
