### PR TITLE
fix: avoid losing focus and temporary values on inputs when performing an operation on blur

### DIFF
--- a/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
+++ b/editors/atlas-exploratory-editor/components/ExploratoryForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
@@ -73,7 +72,7 @@ export function ExploratoryForm({
   };
 
   const baseDocument = useBaseDocumentCached(document, context);
-  const loading = shouldShowSkeleton(mode, baseDocument);
+  const loading = baseDocument === null;
 
   const { preserveSpace, showLastElement } = useElementVisibility({
     mode,
@@ -254,9 +253,7 @@ export function ExploratoryForm({
               loading={loading}
               viewMode={mode}
               showAddField={showLastElement}
-              baselineValue={
-                baseDocument?.state.global.originalContextData ?? []
-              }
+              baselineValue={baseDocument?.state.global.originalContextData}
               label="Original Context Data"
               data={documentState.originalContextData}
               document={document}

--- a/editors/atlas-foundation-editor/components/FoundationForm.tsx
+++ b/editors/atlas-foundation-editor/components/FoundationForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
@@ -67,7 +66,7 @@ export function FoundationForm({
   };
 
   const baseDocument = useBaseDocumentCached(document, context);
-  const loading = shouldShowSkeleton(mode, baseDocument);
+  const loading = baseDocument === null;
 
   const { preserveSpace, showLastElement } = useElementVisibility({
     mode,
@@ -193,9 +192,7 @@ export function FoundationForm({
               loading={loading}
               viewMode={mode}
               showAddField={showLastElement}
-              baselineValue={
-                baseDocument?.state.global.originalContextData ?? []
-              }
+              baselineValue={baseDocument?.state.global.originalContextData}
               label="Original Context Data"
               data={documentState.originalContextData}
               document={document}

--- a/editors/atlas-grounding-editor/components/GroundingForm.tsx
+++ b/editors/atlas-grounding-editor/components/GroundingForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type PHIDOption } from "@powerhousedao/document-engineering/ui";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
@@ -70,7 +69,7 @@ export function GroundingForm({
   };
 
   const baseDocument = useBaseDocumentCached(document, context);
-  const loading = shouldShowSkeleton(mode, baseDocument);
+  const loading = baseDocument === null;
 
   const { preserveSpace, showLastElement } = useElementVisibility({
     mode,
@@ -206,9 +205,7 @@ export function GroundingForm({
               loading={loading}
               showAddField={showLastElement}
               viewMode={mode}
-              baselineValue={
-                baseDocument?.state.global.originalContextData ?? []
-              }
+              baselineValue={baseDocument?.state.global.originalContextData}
               label="Original Context Data"
               data={documentState.originalContextData}
               document={document}

--- a/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
+++ b/editors/atlas-multi-parent-editor/components/MultiparentForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { FormModeProvider } from "../../shared/providers/FormModeProvider.js";
 import type { IProps } from "../editor.js";
@@ -51,7 +50,7 @@ export function MultiParentForm({
   );
 
   const baseDocument = useBaseDocumentCached(document, context);
-  const loading = shouldShowSkeleton(mode, baseDocument);
+  const loading = baseDocument === null;
 
   const { preserveSpace, showLastElement } = useElementVisibility({
     mode,
@@ -151,7 +150,7 @@ export function MultiParentForm({
                 };
               })}
               fetchOptionsCallback={fetchOptionsCallback}
-              baselineValue={baseDocument?.state.global.parents ?? []}
+              baselineValue={baseDocument?.state.global.parents}
               document={document}
               onAdd={(value) => {
                 const newData = fetchOptionsCallback(value)[0];
@@ -215,9 +214,7 @@ export function MultiParentForm({
               loading={loading}
               viewMode={mode}
               showAddField={showLastElement}
-              baselineValue={
-                baseDocument?.state.global.originalContextData ?? []
-              }
+              baselineValue={baseDocument?.state.global.originalContextData}
               label="Original Context Data"
               data={documentState.originalContextData}
               document={document}

--- a/editors/atlas-scope-editor/components/ScopeForm.tsx
+++ b/editors/atlas-scope-editor/components/ScopeForm.tsx
@@ -4,7 +4,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import {
   getFlexLayoutClassName,
@@ -41,7 +40,7 @@ export function ScopeForm({
   const documentState = document.state.global;
 
   const baseDocument = useBaseDocumentCached(document, context);
-  const loading = shouldShowSkeleton(mode, baseDocument);
+  const loading = baseDocument === null;
 
   const { preserveSpace, showLastElement } = useElementVisibility({
     mode,
@@ -113,9 +112,7 @@ export function ScopeForm({
                 loading={loading}
                 viewMode={mode}
                 showAddField={showLastElement}
-                baselineValue={
-                  baseDocument?.state.global.originalContextData ?? []
-                }
+                baselineValue={baseDocument?.state.global.originalContextData}
                 label="Original Context Data"
                 data={documentState.originalContextData}
                 onAdd={(value) => {

--- a/editors/atlas-set-editor/components/SetForm.tsx
+++ b/editors/atlas-set-editor/components/SetForm.tsx
@@ -9,7 +9,6 @@ import {
   getCardVariant,
   getStringValue,
   getTagText,
-  shouldShowSkeleton,
 } from "../../shared/utils/utils.js";
 import { type IProps } from "../editor.js";
 import type { PHIDOption } from "@powerhousedao/document-engineering/ui";
@@ -56,7 +55,7 @@ export function SetForm({
   };
 
   const baseDocument = useBaseDocumentCached(document, context);
-  const loading = shouldShowSkeleton(mode, baseDocument);
+  const loading = baseDocument === null;
 
   return (
     <FormModeProvider mode={mode}>

--- a/editors/shared/utils/array-diff.ts
+++ b/editors/shared/utils/array-diff.ts
@@ -1,6 +1,4 @@
-import { getRevisionFromDate } from "@powerhousedao/common";
 import type { AtlasDocument } from "./utils.js";
-import { getBaseDocumentTimestamp } from "./utils.js";
 import { type Operation } from "document-model";
 
 export interface MatchIndex {
@@ -115,38 +113,17 @@ export function getOperations<T extends AtlasDocument>(
   filterType?: T["operations"]["global"][number]["type"][],
 ): Operation[] {
   try {
-    const baseDocumentTimestamp = getBaseDocumentTimestamp(document);
-    const endDate = new Date(baseDocumentTimestamp);
-    endDate.setUTCSeconds(endDate.getUTCSeconds() + 30);
-
-    const operations = document.operations.global.sort(
-      (a, b) => b.index - a.index,
-    );
-
-    // Get the base revision (same as in useBaseDocumentCached)
-    const baseRevision = getRevisionFromDate(
-      new Date(baseDocumentTimestamp),
-      endDate,
-      operations,
-    );
-
-    const currentRevision = document.header.revision.global;
     const relevantOperations: Operation[] = [];
 
-    // Get all operations from base revision to current revision
+    // Get all operations from index 0 onwards (no revision filtering)
     for (const operation of document.operations.global) {
-      if (
-        operation.index >= baseRevision &&
-        operation.index <= currentRevision
-      ) {
-        // Filter by operation type if filterType is provided
-        if (filterType && filterType.length > 0) {
-          if (filterType.includes(operation.type)) {
-            relevantOperations.push(operation);
-          }
-        } else {
+      // Filter by operation type if filterType is provided
+      if (filterType && filterType.length > 0) {
+        if (filterType.includes(operation.type)) {
           relevantOperations.push(operation);
         }
+      } else {
+        relevantOperations.push(operation);
       }
     }
 

--- a/editors/shared/utils/utils.ts
+++ b/editors/shared/utils/utils.ts
@@ -81,13 +81,6 @@ export const getBaseDocumentTimestamp = (document: AtlasDocument): string => {
   return new Date().toISOString();
 };
 
-export const shouldShowSkeleton = (
-  mode: ViewMode,
-  baseDocument: AtlasDocument | null,
-) => {
-  return mode !== "edition" && baseDocument === null;
-};
-
 interface ShowLastElementOptions {
   mode: ViewMode;
   isSplitMode?: boolean;


### PR DESCRIPTION
## Ticket
https://trello.com/c/ni8CgPnM/1148-arrays-resets-its-value

## Description
- Should make sure that the fields do not reset their values or lose the focus after an operation is executed
- Improve/Avoid the flickering of array fields